### PR TITLE
use values from AVS3 and VVC V&V sequences in DVB NGVC activity

### DIFF
--- a/input/test-115.xml
+++ b/input/test-115.xml
@@ -4,33 +4,46 @@
   <PMT service_id="0">
 
     <AVS3_video_descriptor
-        profile_id="1"
-        level_id="2"
-        multiple_frame_rate_flag="true"
-        frame_rate_code="3"
-        sample_precision="4"
-        chroma_format="2"
+        profile_id="50"
+        level_id="85"
+        multiple_frame_rate_flag="tfalse"
+        frame_rate_code="8"
+        sample_precision="2"
+        chroma_format="1"
         temporal_id_flag="false"
-        td_mode_flag="true"
+        td_mode_flag="false"
         library_stream_flag="false"
-        library_picture_enable_flag="true"
-        colour_primaries="0x1B"
-        transfer_characteristics="0xCD"
-        matrix_coefficients="0xEF"/>
+        library_picture_enable_flag="false"
+        colour_primaries="9"
+        transfer_characteristics="14"
+        matrix_coefficients="8"/>
 
-    <dvb_vvc_subpictures_descriptor
+    <vvc_subpictures_descriptor
       default_service_mode="true"
-      processing_mode="2"
-      service_description="Foo bar">
-    </dvb_vvc_subpictures_descriptor>
+      processing_mode="1"
+      service_description="whole mosaic">
+      <subpicture component_tag="1" subpicture_id="0"/>
+      <subpicture component_tag="1" subpicture_id="1"/>
+      <subpicture component_tag="1" subpicture_id="2"/>
+      <subpicture component_tag="1" subpicture_id="3"/>
+    </vvc_subpictures_descriptor>
 
-    <dvb_vvc_subpictures_descriptor
+    <vvc_subpictures_descriptor
       default_service_mode="false"
-      processing_mode="5"
-      service_description="Scoobidoo">
-      <subpicture component_tag="0x81" subpicture_id="0xAB"/>
-      <subpicture component_tag="0x95" subpicture_id="0xCD"/>
-    </dvb_vvc_subpictures_descriptor>
+      processing_mode="2">
+      <subpicture component_tag="1" subpicture_id="1"/>
+    </vvc_subpictures_descriptor>
+
+    <vvc_subpictures_descriptor
+      default_service_mode="false"
+      processing_mode="6"
+      service_description="picture-in-picture">
+      <subpicture component_tag="1" subpicture_id="1"/>
+      <subpicture component_tag="1" subpicture_id="2"/>
+      <subpicture component_tag="1" subpicture_id="0"/>
+      <subpicture component_tag="1" subpicture_id="3"/>
+      <subpicture component_tag="1" subpicture_id="4"/>
+    </vvc_subpictures_descriptor>
 
     <EVC_timing_and_HRD_descriptor
         hrd_management_valid="true"
@@ -98,30 +111,30 @@
         num_units_in_tick="0x96325841"/>
 
     <VVC_video_descriptor
-        profile_idc="0x74"
-        tier_flag="true"
-        progressive_source_flag="false"
-        interlaced_source_flag="true"
-        non_packed_constraint_flag="false"
-        frame_only_constraint_flag="true"
-        level_idc="0xEB"
-        VVC_still_present_flag="true"
-        VVC_24hr_picture_present_flag="false"/>
-
-    <VVC_video_descriptor
-        profile_idc="0x4F"
+        profile_idc="0x01"
         tier_flag="false"
         progressive_source_flag="true"
         interlaced_source_flag="false"
         non_packed_constraint_flag="true"
         frame_only_constraint_flag="false"
-        level_idc="0x15"
+        level_idc="0x50"
         VVC_still_present_flag="false"
-        VVC_24hr_picture_present_flag="true"
-        HDR_WCG_idc="2"
-        video_properties_tag="9"
+        VVC_24hr_picture_present_flag="false"/>
+
+    <VVC_video_descriptor
+        profile_idc="0x01"
+        tier_flag="false"
+        progressive_source_flag="true"
+        interlaced_source_flag="false"
+        non_packed_constraint_flag="true"
+        frame_only_constraint_flag="false"
+        level_idc="0x66"
+        VVC_still_present_flag="false"
+        VVC_24hr_picture_present_flag="false"
+        HDR_WCG_idc="0"
+        video_properties_tag="0"
         temporal_id_min="3"
-        temporal_id_max="6">
+        temporal_id_max="5">
       <sub_profile_idc value="0x12369874"/>
       <sub_profile_idc value="0x01236985"/>
       <sub_profile_idc value="0x41558723"/>


### PR DESCRIPTION
Small updates to the values in the test elements to be aligned with actual values used in DVB validation and verification activity for these codecs.
Also, use the name defined in EN 300 468 for the XML element, i.e. "vvc_subpictures_descriptor"