### PR TITLE
@HDR_WCG_idc and @video_properties_tag attributes are mandatory in the VVC_video_descriptor

### DIFF
--- a/input/test-115.xml
+++ b/input/test-115.xml
@@ -117,7 +117,9 @@
         frame_only_constraint_flag="false"
         level_idc="0x50"
         VVC_still_present_flag="false"
-        VVC_24hr_picture_present_flag="true"/>
+        VVC_24hr_picture_present_flag="true"
+        HDR_WCG_idc="2"
+        video_properties_tag="4"/>
 
     <VVC_video_descriptor
         profile_idc="0x01"


### PR DESCRIPTION
Added these two attributes as they cannot be defaulted.