### PR TITLE
add missing fpath wrappers to some tests failing under cygwin

### DIFF
--- a/tests/test-041.sh
+++ b/tests/test-041.sh
@@ -13,13 +13,13 @@ INFILE="$INDIR/$SCRIPT.ts"
 #   16:5 17:6 18:6 (no pl) 19:6 (no pl) 20:7 (no pl)
 
 cp "$INFILE" "$OUTDIR/$SCRIPT.tsfixcc.1.ts"
-$(tspath tsfixcc) "$OUTDIR/$SCRIPT.tsfixcc.1.ts" \
+$(tspath tsfixcc) $(fpath "$OUTDIR/$SCRIPT.tsfixcc.1.ts") \
     --verbose --noaction >"$OUTDIR/$SCRIPT.tsfixcc.1.log" 2>&1
 
 test_bin $SCRIPT.tsfixcc.1.ts
 test_text $SCRIPT.tsfixcc.1.log
 
-$(tspath tsdump) "$OUTDIR/$SCRIPT.tsfixcc.1.ts" \
+$(tspath tsdump) $(fpath "$OUTDIR/$SCRIPT.tsfixcc.1.ts") \
     >"$OUTDIR/$SCRIPT.tsfixcc.1.tsdump.txt" \
     2>"$OUTDIR/$SCRIPT.tsfixcc.1.tsdump.log"
 
@@ -27,13 +27,13 @@ test_text $SCRIPT.tsfixcc.1.tsdump.txt
 test_text $SCRIPT.tsfixcc.1.tsdump.log
 
 cp "$INFILE" "$OUTDIR/$SCRIPT.tsfixcc.2.ts"
-$(tspath tsfixcc) "$OUTDIR/$SCRIPT.tsfixcc.2.ts" \
+$(tspath tsfixcc) $(fpath "$OUTDIR/$SCRIPT.tsfixcc.2.ts") \
     --verbose >"$OUTDIR/$SCRIPT.tsfixcc.2.log" 2>&1
 
 test_bin $SCRIPT.tsfixcc.2.ts
 test_text $SCRIPT.tsfixcc.2.log
 
-$(tspath tsdump) "$OUTDIR/$SCRIPT.tsfixcc.2.ts" \
+$(tspath tsdump) $(fpath "$OUTDIR/$SCRIPT.tsfixcc.2.ts") \
     >"$OUTDIR/$SCRIPT.tsfixcc.2.tsdump.txt" \
     2>"$OUTDIR/$SCRIPT.tsfixcc.2.tsdump.log"
 
@@ -52,14 +52,14 @@ test_bin $SCRIPT.tsp.1.ts
 test_bin $SCRIPT.tsp.2.ts
 test_text $SCRIPT.tsp.log
 
-$(tspath tsdump) "$OUTDIR/$SCRIPT.tsp.1.ts" \
+$(tspath tsdump) $(fpath "$OUTDIR/$SCRIPT.tsp.1.ts") \
     >"$OUTDIR/$SCRIPT.tsp.1.tsdump.txt" \
     2>"$OUTDIR/$SCRIPT.tsp.1.tsdump.log"
 
 test_text $SCRIPT.tsp.1.tsdump.txt
 test_text $SCRIPT.tsp.1.tsdump.log
 
-$(tspath tsdump) "$OUTDIR/$SCRIPT.tsp.2.ts" \
+$(tspath tsdump) $(fpath "$OUTDIR/$SCRIPT.tsp.2.ts") \
     >"$OUTDIR/$SCRIPT.tsp.2.tsdump.txt" \
     2>"$OUTDIR/$SCRIPT.tsp.2.tsdump.log"
 

--- a/tests/test-049.sh
+++ b/tests/test-049.sh
@@ -73,14 +73,14 @@ test_bin $SCRIPT.tsp.norep.ts
 test_text $SCRIPT.tsp.norep.log
 
 cp "$INDIR/$SCRIPT.ts" "$OUTDIR/$SCRIPT.tsfixcc.rep.ts"
-$(tspath tsfixcc) "$OUTDIR/$SCRIPT.tsfixcc.rep.ts" \
+$(tspath tsfixcc) $(fpath "$OUTDIR/$SCRIPT.tsfixcc.rep.ts") \
     >"$OUTDIR/$SCRIPT.tsfixcc.rep.log" 2>&1
 
 test_bin $SCRIPT.tsfixcc.rep.ts
 test_text $SCRIPT.tsfixcc.rep.log
 
 cp "$INDIR/$SCRIPT.ts" "$OUTDIR/$SCRIPT.tsfixcc.norep.ts"
-$(tspath tsfixcc) "$OUTDIR/$SCRIPT.tsfixcc.norep.ts" --no-replicate-duplicated \
+$(tspath tsfixcc) $(fpath "$OUTDIR/$SCRIPT.tsfixcc.norep.ts") --no-replicate-duplicated \
     >"$OUTDIR/$SCRIPT.tsfixcc.norep.log" 2>&1
 
 test_bin $SCRIPT.tsfixcc.norep.ts

--- a/tests/test-050.sh
+++ b/tests/test-050.sh
@@ -13,9 +13,9 @@ testeas()
     local file=$SCRIPT.$1
 
     $(tspath tstables) $(fpath "$INDIR/$file.ts") \
-        --text "$OUTDIR/$file.tstables.txt" \
-        --xml "$OUTDIR/$file.tstables.xml" \
-        --bin "$OUTDIR/$file.tstables.bin" \
+        --text $(fpath "$OUTDIR/$file.tstables.txt") \
+        --xml $(fpath "$OUTDIR/$file.tstables.xml") \
+        --bin $(fpath "$OUTDIR/$file.tstables.bin") \
         &>"$OUTDIR/$file.tstables.log"
 
     test_bin $file.tstables.bin

--- a/tests/test-051.sh
+++ b/tests/test-051.sh
@@ -8,9 +8,9 @@ INFILE="$INDIR/test-040.ts"
 
 # Extract tables in various forms.
 $(tspath tstables) $(fpath "$INFILE") --tid 0xCB \
-    --text "$OUTDIR/$SCRIPT.tstables.txt" \
-    --xml "$OUTDIR/$SCRIPT.tstables.xml" \
-    --bin "$OUTDIR/$SCRIPT.tstables.bin" \
+    --text $(fpath "$OUTDIR/$SCRIPT.tstables.txt") \
+    --xml $(fpath "$OUTDIR/$SCRIPT.tstables.xml") \
+    --bin $(fpath "$OUTDIR/$SCRIPT.tstables.bin") \
     &>"$OUTDIR/$SCRIPT.tstables.log"
 
 test_bin $SCRIPT.tstables.bin

--- a/tests/test-052.sh
+++ b/tests/test-052.sh
@@ -8,9 +8,9 @@ INFILE="$INDIR/$SCRIPT.ts"
 
 # Extract tables in various forms.
 $(tspath tstables) $(fpath "$INFILE") --tid 0xCA \
-    --text "$OUTDIR/$SCRIPT.tstables.txt" \
-    --xml "$OUTDIR/$SCRIPT.tstables.xml" \
-    --bin "$OUTDIR/$SCRIPT.tstables.bin" \
+    --text $(fpath "$OUTDIR/$SCRIPT.tstables.txt") \
+    --xml $(fpath "$OUTDIR/$SCRIPT.tstables.xml") \
+    --bin $(fpath "$OUTDIR/$SCRIPT.tstables.bin") \
     &>"$OUTDIR/$SCRIPT.tstables.log"
 
 test_bin $SCRIPT.tstables.bin


### PR DESCRIPTION
Some tests were failing in my windows+cygwin environment due to files not found.
