### PR TITLE
ISO/IEC 13818-1 9th edition changes 'FlexMux' to 'M4Mux'

### DIFF
--- a/input/test-015.xml
+++ b/input/test-015.xml
@@ -993,12 +993,12 @@
     <FMC_descriptor/>
 
     <FMC_descriptor>
-      <stream ES_ID="0x1234" FlexMuxChannel="0xAB"/>
-      <stream ES_ID="0x5678" FlexMuxChannel="0xCD"/>
-      <stream ES_ID="0x9ABC" FlexMuxChannel="0xEF"/>
+      <stream ES_ID="0x1234" M4MuxChannel="0xAB"/>
+      <stream ES_ID="0x5678" M4MuxChannel="0xCD"/>
+      <stream ES_ID="0x9ABC" M4MuxChannel="0xEF"/>
     </FMC_descriptor>
 
-    <flexmux_timing_descriptor
+    <m4mux_timing_descriptor
         FCR_ES_ID="0x1234"
         FCRResolution="0x56789ABC"
         FCRLength="0xDE"

--- a/input/test-115.xml
+++ b/input/test-115.xml
@@ -271,20 +271,20 @@
 	  </MuxCodeEntry>
 	</MuxCode_descriptor>
 
-	<FmxBufferSize_descriptor>
-		<DefaultFlexMuxBufferDescriptor flexMuxChannel="156" FB_BufferSize="15549729"/>
-	</FmxBufferSize_descriptor>
+	<M4MuxBufferSize_descriptor>
+		<DefaultM4MuxBufferDescriptor m4MuxChannel="156" FB_BufferSize="15549729"/>
+	</M4MuxBufferSize_descriptor>
 	
-	<FmxBufferSize_descriptor>
-		<DefaultFlexMuxBufferDescriptor flexMuxChannel="201" FB_BufferSize="8208677"/>
-		<FlexMuxBufferDescriptor flexMuxChannel="17" FB_BufferSize="901127"/>
-	</FmxBufferSize_descriptor>
+	<M4MuxBufferSize_descriptor>
+		<DefaultM4MuxBufferDescriptor m4MuxChannel="201" FB_BufferSize="8208677"/>
+		<M4MuxBufferDescriptor m4MuxChannel="17" FB_BufferSize="901127"/>
+	</M4MuxBufferSize_descriptor>
 	
-	<FmxBufferSize_descriptor>
-		<DefaultFlexMuxBufferDescriptor flexMuxChannel="42" FB_BufferSize="1234567"/>
-		<FlexMuxBufferDescriptor flexMuxChannel="177" FB_BufferSize="901127"/>
-		<FlexMuxBufferDescriptor flexMuxChannel="178" FB_BufferSize="901127"/>
-	</FmxBufferSize_descriptor>
+	<M4MuxBufferSize_descriptor>
+		<DefaultM4MuxBufferDescriptor m4MuxChannel="42" FB_BufferSize="1234567"/>
+		<M4MuxBufferDescriptor m4MuxChannel="177" FB_BufferSize="901127"/>
+		<M4MuxBufferDescriptor m4MuxChannel="178" FB_BufferSize="901127"/>
+	</M4MuxBufferSize_descriptor>
 	
 	<HEVC_operation_point_descriptor>
 		<operation_point 

--- a/reference/test-005/test-005.tstabdump.txt
+++ b/reference/test-005/test-005.tstabdump.txt
@@ -25,7 +25,7 @@
   Program information:
   - Descriptor 0: CA (0x09, 9), 4 bytes
     CA System Id: 0x0777 (Jerrold/GI/Motorola), ECM PID: 593 (0x0251)
-  Elementary stream: type 0x12 (MPEG-4 SL or FlexMux in PES packets), PID: 1383 (0x0567)
+  Elementary stream: type 0x12 (MPEG-4 SL or M4Mux in PES packets), PID: 1383 (0x0567)
   - Descriptor 0: ISO-639 Language (0x0A, 10), 8 bytes
     Language: fre, Type: 0x45 (unknown)
     Language: deu, Type: 0x78 (unknown)

--- a/reference/test-005/test-005.tstables.txt
+++ b/reference/test-005/test-005.tstables.txt
@@ -28,7 +28,7 @@
     Program information:
     - Descriptor 0: CA (0x09, 9), 4 bytes
       CA System Id: 0x0777 (Jerrold/GI/Motorola), ECM PID: 593 (0x0251)
-    Elementary stream: type 0x12 (MPEG-4 SL or FlexMux in PES packets), PID: 1383 (0x0567)
+    Elementary stream: type 0x12 (MPEG-4 SL or M4Mux in PES packets), PID: 1383 (0x0567)
     - Descriptor 0: ISO-639 Language (0x0A, 10), 8 bytes
       Language: fre, Type: 0x45 (unknown)
       Language: deu, Type: 0x78 (unknown)

--- a/reference/test-015/test-015.decompile.json
+++ b/reference/test-015/test-015.decompile.json
@@ -1737,22 +1737,22 @@
           {
             "#name": "stream",
             "es_id": 4660,
-            "flexmuxchannel": 171
+            "m4muxchannel": 171
           },
           {
             "#name": "stream",
             "es_id": 22136,
-            "flexmuxchannel": 205
+            "m4muxchannel": 205
           },
           {
             "#name": "stream",
             "es_id": 39612,
-            "flexmuxchannel": 239
+            "m4muxchannel": 239
           }
         ]
       },
       {
-        "#name": "flexmux_timing_descriptor",
+        "#name": "m4mux_timing_descriptor",
         "fcr_es_id": 4660,
         "fcrlength": 222,
         "fcrresolution": 1450744508,

--- a/reference/test-015/test-015.decompile.strict.xml
+++ b/reference/test-015/test-015.decompile.strict.xml
@@ -415,11 +415,11 @@
     <metadata_STD_descriptor metadata_input_leak_rate="123,456" metadata_buffer_size="789,012" metadata_output_leak_rate="4,194,303"/>
     <FMC_descriptor/>
     <FMC_descriptor>
-      <stream ES_ID="0x1234" FlexMuxChannel="0xAB"/>
-      <stream ES_ID="0x5678" FlexMuxChannel="0xCD"/>
-      <stream ES_ID="0x9ABC" FlexMuxChannel="0xEF"/>
+      <stream ES_ID="0x1234" M4MuxChannel="0xAB"/>
+      <stream ES_ID="0x5678" M4MuxChannel="0xCD"/>
+      <stream ES_ID="0x9ABC" M4MuxChannel="0xEF"/>
     </FMC_descriptor>
-    <flexmux_timing_descriptor FCR_ES_ID="0x1234" FCRResolution="1,450,744,508" FCRLength="222" FmxRateLength="171"/>
+    <m4mux_timing_descriptor FCR_ES_ID="0x1234" FCRResolution="1,450,744,508" FCRLength="222" FmxRateLength="171"/>
     <multiplex_buffer_descriptor MB_buffer_size="123,456" TB_leak_rate="789,012"/>
     <MPEG2_stereoscopic_video_format_descriptor/>
     <MPEG2_stereoscopic_video_format_descriptor arrangement_type="0x67"/>

--- a/reference/test-015/test-015.decompile.xml
+++ b/reference/test-015/test-015.decompile.xml
@@ -415,11 +415,11 @@
     <metadata_STD_descriptor metadata_input_leak_rate="123,456" metadata_buffer_size="789,012" metadata_output_leak_rate="4,194,303"/>
     <FMC_descriptor/>
     <FMC_descriptor>
-      <stream ES_ID="0x1234" FlexMuxChannel="0xAB"/>
-      <stream ES_ID="0x5678" FlexMuxChannel="0xCD"/>
-      <stream ES_ID="0x9ABC" FlexMuxChannel="0xEF"/>
+      <stream ES_ID="0x1234" M4MuxChannel="0xAB"/>
+      <stream ES_ID="0x5678" M4MuxChannel="0xCD"/>
+      <stream ES_ID="0x9ABC" M4MuxChannel="0xEF"/>
     </FMC_descriptor>
-    <flexmux_timing_descriptor FCR_ES_ID="0x1234" FCRResolution="1,450,744,508" FCRLength="222" FmxRateLength="171"/>
+    <m4mux_timing_descriptor FCR_ES_ID="0x1234" FCRResolution="1,450,744,508" FCRLength="222" FmxRateLength="171"/>
     <multiplex_buffer_descriptor MB_buffer_size="123,456" TB_leak_rate="789,012"/>
     <MPEG2_stereoscopic_video_format_descriptor/>
     <MPEG2_stereoscopic_video_format_descriptor arrangement_type="0x67"/>

--- a/reference/test-015/test-015.tstabdump.txt
+++ b/reference/test-015/test-015.tstabdump.txt
@@ -802,7 +802,7 @@
     ES id: 0x1234 (4660), M4Mux channel: 0xAB (171)
     ES id: 0x5678 (22136), M4Mux channel: 0xCD (205)
     ES id: 0x9ABC (39612), M4Mux channel: 0xEF (239)
-  - Descriptor 62: FlexMuxTiming (0x2C, 44), 8 bytes
+  - Descriptor 62: M4Mux Timing (0x2C, 44), 8 bytes
     FCR ES ID: 0x1234 (4660)
     FCR resolution: 1,450,744,508 cycles/second
     FCR length: 222

--- a/reference/test-015/test-015.tstabdump.txt
+++ b/reference/test-015/test-015.tstabdump.txt
@@ -799,9 +799,9 @@
     Metadata output leak rate: 4,194,303 (1,677,721,200 bits/s)
   - Descriptor 60: FMC (0x1F, 31), 0 bytes
   - Descriptor 61: FMC (0x1F, 31), 9 bytes
-    ES id: 0x1234 (4660), FlexMux channel: 0xAB (171)
-    ES id: 0x5678 (22136), FlexMux channel: 0xCD (205)
-    ES id: 0x9ABC (39612), FlexMux channel: 0xEF (239)
+    ES id: 0x1234 (4660), M4Mux channel: 0xAB (171)
+    ES id: 0x5678 (22136), M4Mux channel: 0xCD (205)
+    ES id: 0x9ABC (39612), M4Mux channel: 0xEF (239)
   - Descriptor 62: FlexMuxTiming (0x2C, 44), 8 bytes
     FCR ES ID: 0x1234 (4660)
     FCR resolution: 1,450,744,508 cycles/second

--- a/reference/test-015/test-015.tstables.strict.xml
+++ b/reference/test-015/test-015.tstables.strict.xml
@@ -422,11 +422,11 @@
     <metadata_STD_descriptor metadata_input_leak_rate="123,456" metadata_buffer_size="789,012" metadata_output_leak_rate="4,194,303"/>
     <FMC_descriptor/>
     <FMC_descriptor>
-      <stream ES_ID="0x1234" FlexMuxChannel="0xAB"/>
-      <stream ES_ID="0x5678" FlexMuxChannel="0xCD"/>
-      <stream ES_ID="0x9ABC" FlexMuxChannel="0xEF"/>
+      <stream ES_ID="0x1234" M4MuxChannel="0xAB"/>
+      <stream ES_ID="0x5678" M4MuxChannel="0xCD"/>
+      <stream ES_ID="0x9ABC" M4MuxChannel="0xEF"/>
     </FMC_descriptor>
-    <flexmux_timing_descriptor FCR_ES_ID="0x1234" FCRResolution="1,450,744,508" FCRLength="222" FmxRateLength="171"/>
+    <m4mux_timing_descriptor FCR_ES_ID="0x1234" FCRResolution="1,450,744,508" FCRLength="222" FmxRateLength="171"/>
     <multiplex_buffer_descriptor MB_buffer_size="123,456" TB_leak_rate="789,012"/>
     <MPEG2_stereoscopic_video_format_descriptor/>
     <MPEG2_stereoscopic_video_format_descriptor arrangement_type="0x67"/>

--- a/reference/test-015/test-015.tstables.txt
+++ b/reference/test-015/test-015.tstables.txt
@@ -804,9 +804,9 @@
       Metadata output leak rate: 4,194,303 (1,677,721,200 bits/s)
     - Descriptor 60: FMC (0x1F, 31), 0 bytes
     - Descriptor 61: FMC (0x1F, 31), 9 bytes
-      ES id: 0x1234 (4660), FlexMux channel: 0xAB (171)
-      ES id: 0x5678 (22136), FlexMux channel: 0xCD (205)
-      ES id: 0x9ABC (39612), FlexMux channel: 0xEF (239)
+      ES id: 0x1234 (4660), M4Mux channel: 0xAB (171)
+      ES id: 0x5678 (22136), M4Mux channel: 0xCD (205)
+      ES id: 0x9ABC (39612), M4Mux channel: 0xEF (239)
     - Descriptor 62: FlexMuxTiming (0x2C, 44), 8 bytes
       FCR ES ID: 0x1234 (4660)
       FCR resolution: 1,450,744,508 cycles/second

--- a/reference/test-015/test-015.tstables.txt
+++ b/reference/test-015/test-015.tstables.txt
@@ -807,7 +807,7 @@
       ES id: 0x1234 (4660), M4Mux channel: 0xAB (171)
       ES id: 0x5678 (22136), M4Mux channel: 0xCD (205)
       ES id: 0x9ABC (39612), M4Mux channel: 0xEF (239)
-    - Descriptor 62: FlexMuxTiming (0x2C, 44), 8 bytes
+    - Descriptor 62: M4Mux Timing (0x2C, 44), 8 bytes
       FCR ES ID: 0x1234 (4660)
       FCR resolution: 1,450,744,508 cycles/second
       FCR length: 222

--- a/reference/test-015/test-015.tstables.xml
+++ b/reference/test-015/test-015.tstables.xml
@@ -422,11 +422,11 @@
     <metadata_STD_descriptor metadata_input_leak_rate="123,456" metadata_buffer_size="789,012" metadata_output_leak_rate="4,194,303"/>
     <FMC_descriptor/>
     <FMC_descriptor>
-      <stream ES_ID="0x1234" FlexMuxChannel="0xAB"/>
-      <stream ES_ID="0x5678" FlexMuxChannel="0xCD"/>
-      <stream ES_ID="0x9ABC" FlexMuxChannel="0xEF"/>
+      <stream ES_ID="0x1234" M4MuxChannel="0xAB"/>
+      <stream ES_ID="0x5678" M4MuxChannel="0xCD"/>
+      <stream ES_ID="0x9ABC" M4MuxChannel="0xEF"/>
     </FMC_descriptor>
-    <flexmux_timing_descriptor FCR_ES_ID="0x1234" FCRResolution="1,450,744,508" FCRLength="222" FmxRateLength="171"/>
+    <m4mux_timing_descriptor FCR_ES_ID="0x1234" FCRResolution="1,450,744,508" FCRLength="222" FmxRateLength="171"/>
     <multiplex_buffer_descriptor MB_buffer_size="123,456" TB_leak_rate="789,012"/>
     <MPEG2_stereoscopic_video_format_descriptor/>
     <MPEG2_stereoscopic_video_format_descriptor arrangement_type="0x67"/>

--- a/reference/test-115/test-115.decompile.json
+++ b/reference/test-115/test-115.decompile.json
@@ -478,47 +478,47 @@
         ]
       },
       {
-        "#name": "FmxBufferSize_descriptor",
+        "#name": "M4MuxBufferSize_descriptor",
         "#nodes": [
           {
-            "#name": "DefaultFlexMuxBufferDescriptor",
+            "#name": "DefaultM4MuxBufferDescriptor",
             "fb_buffersize": 15549729,
-            "flexmuxchannel": 156
+            "m4muxchannel": 156
           }
         ]
       },
       {
-        "#name": "FmxBufferSize_descriptor",
+        "#name": "M4MuxBufferSize_descriptor",
         "#nodes": [
           {
-            "#name": "DefaultFlexMuxBufferDescriptor",
+            "#name": "DefaultM4MuxBufferDescriptor",
             "fb_buffersize": 8208677,
-            "flexmuxchannel": 201
+            "m4muxchannel": 201
           },
           {
-            "#name": "FlexMuxBufferDescriptor",
+            "#name": "M4MuxBufferDescriptor",
             "fb_buffersize": 901127,
-            "flexmuxchannel": 17
+            "m4muxchannel": 17
           }
         ]
       },
       {
-        "#name": "FmxBufferSize_descriptor",
+        "#name": "M4MuxBufferSize_descriptor",
         "#nodes": [
           {
-            "#name": "DefaultFlexMuxBufferDescriptor",
+            "#name": "DefaultM4MuxBufferDescriptor",
             "fb_buffersize": 1234567,
-            "flexmuxchannel": 42
+            "m4muxchannel": 42
           },
           {
-            "#name": "FlexMuxBufferDescriptor",
+            "#name": "M4MuxBufferDescriptor",
             "fb_buffersize": 901127,
-            "flexmuxchannel": 177
+            "m4muxchannel": 177
           },
           {
-            "#name": "FlexMuxBufferDescriptor",
+            "#name": "M4MuxBufferDescriptor",
             "fb_buffersize": 901127,
-            "flexmuxchannel": 178
+            "m4muxchannel": 178
           }
         ]
       },

--- a/reference/test-115/test-115.decompile.strict.xml
+++ b/reference/test-115/test-115.decompile.strict.xml
@@ -103,18 +103,18 @@
         </substructure>
       </MuxCodeEntry>
     </MuxCode_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="156" FB_BufferSize="15,549,729"/>
-    </FmxBufferSize_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="201" FB_BufferSize="8,208,677"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="17" FB_BufferSize="901,127"/>
-    </FmxBufferSize_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="42" FB_BufferSize="1,234,567"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="177" FB_BufferSize="901,127"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="178" FB_BufferSize="901,127"/>
-    </FmxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="156" FB_BufferSize="15,549,729"/>
+    </M4MuxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="201" FB_BufferSize="8,208,677"/>
+      <M4MuxBufferDescriptor m4MuxChannel="17" FB_BufferSize="901,127"/>
+    </M4MuxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="42" FB_BufferSize="1,234,567"/>
+      <M4MuxBufferDescriptor m4MuxChannel="177" FB_BufferSize="901,127"/>
+      <M4MuxBufferDescriptor m4MuxChannel="178" FB_BufferSize="901,127"/>
+    </M4MuxBufferSize_descriptor>
     <HEVC_operation_point_descriptor>
       <operation_point target_ols="156" constant_frame_rate_info_idc="0" applicable_temporal_id="6"/>
     </HEVC_operation_point_descriptor>

--- a/reference/test-115/test-115.decompile.xml
+++ b/reference/test-115/test-115.decompile.xml
@@ -103,18 +103,18 @@
         </substructure>
       </MuxCodeEntry>
     </MuxCode_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="156" FB_BufferSize="15,549,729"/>
-    </FmxBufferSize_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="201" FB_BufferSize="8,208,677"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="17" FB_BufferSize="901,127"/>
-    </FmxBufferSize_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="42" FB_BufferSize="1,234,567"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="177" FB_BufferSize="901,127"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="178" FB_BufferSize="901,127"/>
-    </FmxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="156" FB_BufferSize="15,549,729"/>
+    </M4MuxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="201" FB_BufferSize="8,208,677"/>
+      <M4MuxBufferDescriptor m4MuxChannel="17" FB_BufferSize="901,127"/>
+    </M4MuxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="42" FB_BufferSize="1,234,567"/>
+      <M4MuxBufferDescriptor m4MuxChannel="177" FB_BufferSize="901,127"/>
+      <M4MuxBufferDescriptor m4MuxChannel="178" FB_BufferSize="901,127"/>
+    </M4MuxBufferSize_descriptor>
     <HEVC_operation_point_descriptor>
       <operation_point target_ols="156" constant_frame_rate_info_idc="0" applicable_temporal_id="6"/>
     </HEVC_operation_point_descriptor>

--- a/reference/test-115/test-115.tstabdump.txt
+++ b/reference/test-115/test-115.tstabdump.txt
@@ -168,14 +168,14 @@
       M4 mux channel: 240, byte count: 16
       M4 mux channel: 1, byte count: 253
   - Descriptor 30: FmxBufferSize (0x22, 34), 4 bytes
-     FlexMuxBuffer(default) channel: 156, size: 15549729
+     M4MuxBuffer(default) channel: 156, size: 15549729
   - Descriptor 31: FmxBufferSize (0x22, 34), 8 bytes
-     FlexMuxBuffer(default) channel: 201, size: 8208677
-     FlexMuxBuffer(0) channel: 17, size: 901127
+     M4MuxBuffer(default) channel: 201, size: 8208677
+     M4MuxBuffer(0) channel: 17, size: 901127
   - Descriptor 32: FmxBufferSize (0x22, 34), 12 bytes
-     FlexMuxBuffer(default) channel: 42, size: 1234567
-     FlexMuxBuffer(0) channel: 177, size: 901127
-     FlexMuxBuffer(1) channel: 178, size: 901127
+     M4MuxBuffer(default) channel: 42, size: 1234567
+     M4MuxBuffer(0) channel: 177, size: 901127
+     M4MuxBuffer(1) channel: 178, size: 901127
   - Descriptor 33: MPEG-2 Extension (0x3F, 63), 7 bytes
     MPEG extended descriptor: HEVC Operation Point (0x05, 5)
     operation point[ 0]  target OLS: 156

--- a/reference/test-115/test-115.tstables.strict.xml
+++ b/reference/test-115/test-115.tstables.strict.xml
@@ -104,18 +104,18 @@
         </substructure>
       </MuxCodeEntry>
     </MuxCode_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="156" FB_BufferSize="15,549,729"/>
-    </FmxBufferSize_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="201" FB_BufferSize="8,208,677"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="17" FB_BufferSize="901,127"/>
-    </FmxBufferSize_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="42" FB_BufferSize="1,234,567"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="177" FB_BufferSize="901,127"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="178" FB_BufferSize="901,127"/>
-    </FmxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="156" FB_BufferSize="15,549,729"/>
+    </M4MuxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="201" FB_BufferSize="8,208,677"/>
+      <M4MuxBufferDescriptor m4MuxChannel="17" FB_BufferSize="901,127"/>
+    </M4MuxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="42" FB_BufferSize="1,234,567"/>
+      <M4MuxBufferDescriptor m4MuxChannel="177" FB_BufferSize="901,127"/>
+      <M4MuxBufferDescriptor m4MuxChannel="178" FB_BufferSize="901,127"/>
+    </M4MuxBufferSize_descriptor>
     <HEVC_operation_point_descriptor>
       <operation_point target_ols="156" constant_frame_rate_info_idc="0" applicable_temporal_id="6"/>
     </HEVC_operation_point_descriptor>

--- a/reference/test-115/test-115.tstables.txt
+++ b/reference/test-115/test-115.tstables.txt
@@ -169,14 +169,14 @@
         M4 mux channel: 240, byte count: 16
         M4 mux channel: 1, byte count: 253
     - Descriptor 30: FmxBufferSize (0x22, 34), 4 bytes
-       FlexMuxBuffer(default) channel: 156, size: 15549729
+       M4MuxBuffer(default) channel: 156, size: 15549729
     - Descriptor 31: FmxBufferSize (0x22, 34), 8 bytes
-       FlexMuxBuffer(default) channel: 201, size: 8208677
-       FlexMuxBuffer(0) channel: 17, size: 901127
+       M4MuxBuffer(default) channel: 201, size: 8208677
+       M4MuxBuffer(0) channel: 17, size: 901127
     - Descriptor 32: FmxBufferSize (0x22, 34), 12 bytes
-       FlexMuxBuffer(default) channel: 42, size: 1234567
-       FlexMuxBuffer(0) channel: 177, size: 901127
-       FlexMuxBuffer(1) channel: 178, size: 901127
+       M4MuxBuffer(default) channel: 42, size: 1234567
+       M4MuxBuffer(0) channel: 177, size: 901127
+       M4MuxBuffer(1) channel: 178, size: 901127
     - Descriptor 33: MPEG-2 Extension (0x3F, 63), 7 bytes
       MPEG extended descriptor: HEVC Operation Point (0x05, 5)
       operation point[ 0]  target OLS: 156

--- a/reference/test-115/test-115.tstables.xml
+++ b/reference/test-115/test-115.tstables.xml
@@ -104,18 +104,18 @@
         </substructure>
       </MuxCodeEntry>
     </MuxCode_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="156" FB_BufferSize="15,549,729"/>
-    </FmxBufferSize_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="201" FB_BufferSize="8,208,677"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="17" FB_BufferSize="901,127"/>
-    </FmxBufferSize_descriptor>
-    <FmxBufferSize_descriptor>
-      <DefaultFlexMuxBufferDescriptor flexMuxChannel="42" FB_BufferSize="1,234,567"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="177" FB_BufferSize="901,127"/>
-      <FlexMuxBufferDescriptor flexMuxChannel="178" FB_BufferSize="901,127"/>
-    </FmxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="156" FB_BufferSize="15,549,729"/>
+    </M4MuxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="201" FB_BufferSize="8,208,677"/>
+      <M4MuxBufferDescriptor m4MuxChannel="17" FB_BufferSize="901,127"/>
+    </M4MuxBufferSize_descriptor>
+    <M4MuxBufferSize_descriptor>
+      <DefaultM4MuxBufferDescriptor m4MuxChannel="42" FB_BufferSize="1,234,567"/>
+      <M4MuxBufferDescriptor m4MuxChannel="177" FB_BufferSize="901,127"/>
+      <M4MuxBufferDescriptor m4MuxChannel="178" FB_BufferSize="901,127"/>
+    </M4MuxBufferSize_descriptor>
     <HEVC_operation_point_descriptor>
       <operation_point target_ols="156" constant_frame_rate_info_idc="0" applicable_temporal_id="6"/>
     </HEVC_operation_point_descriptor>


### PR DESCRIPTION
Affected components:
Descriptors related to FlexMux, which is now known (in ISO/IEC13818-1) as M4Mux

Brief description of the proposed changes:
Changes to descriptor and property names to reflect use of M4Mux