### PR TITLE
Fixed test-005 after handleInvalidSection fix

### DIFF
--- a/reference/test-005/test-005.tstables.txt
+++ b/reference/test-005/test-005.tstables.txt
@@ -38,7 +38,7 @@
       Extraneous 3 bytes:
       0000:  01 02 03                                   ...
 
-* Invalid section, invalid CRC32, corrupted section
+* Invalid section
   TSDT, TID 3 (0x03), PID 200 (0x00C8), 28 bytes:
     0000:  03 B0 19 FF FF C2 00 00 47 06 74 73 64 74 20 31  ........G.tsdt 1
     0010:  47 06 74 73 64 74 20 32 77 A6 8F AF              G.tsdt 2w...
@@ -216,7 +216,7 @@
     - Descriptor 1: Bouquet Name (0x47, 71), 6 bytes
       Name: "nit 22"
 
-* Invalid section, invalid CRC32, corrupted section
+* Invalid section
   BAT, TID 74 (0x4A), PID 200 (0x00C8), 52 bytes:
     0000:  4A F0 31 92 1A E6 00 00 F0 08 47 06 62 61 74 20  J.1.......G.bat
     0010:  33 31 F0 1C 98 23 00 18 F0 08 47 06 62 61 74 20  31...#....G.bat


### PR DESCRIPTION
test-005.tstables.txt reference data was invalid. It can be verified using Wireshark or Tshark using filter: mpeg_sect.crc.status != "Good"

This fix is related to 614fae300ce50e9c57b901cf03b6787a7cad3fbf commit in tsduck repository.