### PR TITLE
Added exclude option for asan-enabled tests

### DIFF
--- a/common/testrc.sh
+++ b/common/testrc.sh
@@ -379,6 +379,15 @@ native_only() {
     fi
 }
 
+# Abort current test if testing on asan build
+# Useful to skip java/python tests and tests use libraries with memory leaks and other issues.
+exclude_on_asan() {
+    if [[ $ASAN_RUN ]]; then
+        info "$PRPASS  $SCRIPT: skipped on asan build"
+        exit $EXIT_SUCCESS
+    fi
+}
+
 # Cleanup temporary output file matching a wildcard.
 # Syntax: test_cleanup test-file-wildcard
 test_cleanup() {

--- a/tests/test-080.sh
+++ b/tests/test-080.sh
@@ -4,6 +4,7 @@
 source $(dirname $0)/../common/testrc.sh
 test_cleanup "$SCRIPT.*"
 native_only
+exclude_on_asan
 
 $PYTHON $(fpath "$INDIR/$SCRIPT.py") $(fpath "$INDIR/test-001.ts") >"$OUTDIR/$SCRIPT.log" 2>&1
 

--- a/tests/test-081.sh
+++ b/tests/test-081.sh
@@ -4,6 +4,7 @@
 source $(dirname $0)/../common/testrc.sh
 test_cleanup "$SCRIPT.*"
 native_only
+exclude_on_asan
 
 WORKDIR="$TMPDIR/$SCRIPT.d"
 mkdir -p "$WORKDIR"

--- a/tests/test-086.sh
+++ b/tests/test-086.sh
@@ -4,6 +4,7 @@
 source $(dirname $0)/../common/testrc.sh
 test_cleanup "$SCRIPT.*"
 native_only
+exclude_on_asan
 
 INFILE="$INDIR/test-001.ts"
 OUTFILE="$TMPDIR/$SCRIPT.ts"

--- a/tests/test-087.sh
+++ b/tests/test-087.sh
@@ -4,6 +4,7 @@
 source $(dirname $0)/../common/testrc.sh
 test_cleanup "$SCRIPT.*"
 native_only
+exclude_on_asan
 
 INFILE="$INDIR/test-001.ts"
 OUTFILE="$TMPDIR/$SCRIPT.ts"

--- a/tests/test-130.sh
+++ b/tests/test-130.sh
@@ -4,6 +4,10 @@
 source $(dirname $0)/../common/testrc.sh
 test_cleanup "$SCRIPT.*"
 
+# disabled on asan build due to openssl 1.1 well-known memleak
+# this test should be enabled when CI ubuntu-latest becomes 24.04
+exclude_on_asan
+
 # Run the test only if srt is supported on this platform
 if $(tspath tsversion) --support srt; then
 


### PR DESCRIPTION
Some tests fail if asan is used. It happens if tsduck is used in java or python or external library has an issue like some versions of openssl 1.1.
This PR allows to disable such tests
I will open another PR in tsduck repo for asan build&tests.