### PR TITLE
ComponentDescriptor::stream_content_ext improvement

### DIFF
--- a/reference/test-001/test-001.tstabdump.txt
+++ b/reference/test-001/test-001.tstabdump.txt
@@ -1557,11 +1557,11 @@
       "PrØsentateur" : "Julien Desvages"
       Text: "EN DIRECT.  TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -1592,11 +1592,11 @@
       "PrØsentateur" : "Julien Desvages"
       Text: "EN DIRECT.  TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -1626,11 +1626,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Gant d'Or 2017. Finale. A Biarritz (PyrØnØes-Atlantiques)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1661,11 +1661,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Lorient (L2) / Lens (L2) Coupe de la Ligue. 2e tour."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1707,19 +1707,19 @@
       Language: fre
       Text: "n chien. Il s'en dØbarrasse rapidement. Pris de remords, il dØcide de l'aider."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -1762,15 +1762,15 @@
       Language: fre
       Text: "DIFFUSE EN HD.  "EtØ 2011". Avec l'humour et la tchatche qui le caractØrisent, Kamel, intervenant rØgulier du «Grand Journal», propose des tours de magie rØalisØs dans des lieux insolites."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -1813,19 +1813,19 @@
       Language: fre
       Text: "nØes dans les bois. Sans famille, il prØtend avoir ØtØ ØlevØ par un dragon gØant."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -1863,19 +1863,19 @@
       Language: fre
       Text: "d, Diego, Manny et leurs amis cherchent un moyen de stopper l'apocalypse imminente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -1913,15 +1913,15 @@
       Language: fre
       Text: "ir afin de pouvoir combattre un cruel ennemi qui menace le monde des humains."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -1967,15 +1967,15 @@
       Language: fre
       Text: "it Prince."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -2079,15 +2079,15 @@
       Language: fre
       Text: "obile."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -2125,15 +2125,15 @@
       Language: fre
       Text: "le but de percer le secret de la subtile «nihon ryħri», la cuisine nippone."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -2176,19 +2176,19 @@
       Language: fre
       Text: "tour au commissariat. Amy s'interroge sur les longues pauses effectuØes par Rosa."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -2233,19 +2233,19 @@
       Language: fre
       Text: "ets au sein du commissariat. Chacun se dØmŁne pour avoir le trophØe en jeu."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -2290,15 +2290,15 @@
       Language: fre
       Text: "s connu. Il se rend Ω MontrØal afin d'en savoir plus sur lui."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -2340,15 +2340,15 @@
       Language: fre
       Text: "rise de remords, la praticienne dØcide d'enquŒter sur l'inconnue."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -2405,19 +2405,19 @@
       Language: fre
       Text: "d'arrŒter un soldat sudiste qui a massacrØ sa famille."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -2463,19 +2463,19 @@
       Language: fre
       Text: "pour fournir au FBI les preuves nØcessaires Ω un Øventuel procŁs."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -2518,19 +2518,19 @@
       Language: fre
       Text: "contre une jeune hØritiŁre extravagante et son gentil lØopard."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -2579,19 +2579,19 @@
       Language: fre
       Text: "idieusement dans l'intimitØ d'une vedette de thØĐtre sur le dØclin."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -2628,11 +2628,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -2662,11 +2662,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -2702,11 +2702,11 @@
       Language: fre
       Text: "lise. Elle peut organiser un grand festival des animaux."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -2743,11 +2743,11 @@
       Language: fre
       Text: "er les idØes, Peter Pan organise une chasse au trØsor sur Neverland.."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -2784,15 +2784,15 @@
       Language: fre
       Text: "le amitiØ, qui se transforme ensuite en un amour vØritable : un conte de fØe."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -2829,15 +2829,15 @@
       Language: fre
       Text: "re, dØcouvre et dØnonce les manigances de la future prØsidente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -2868,11 +2868,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -2922,11 +2922,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -2982,15 +2982,15 @@
       Language: fre
       Text: "pprocher le plus prŁs possible."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -3027,15 +3027,15 @@
       Language: fre
       Text: "a taille d'un homme : le poisson-chat."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -3066,11 +3066,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3100,11 +3100,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3140,11 +3140,11 @@
       Language: fre
       Text: "prŁs de 1% de la population du monde occidental."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -3186,11 +3186,11 @@
       "PrØsentateur" : "JØrħme Bonaldi"
       Text: "Le mag de la science : hebdo PrØsentØ par JØrħme Bonaldi. Au sommaire : "Pirogue en Picardie". - "Le caoutchouc". - "Le latex". - "Le camØlØon"."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3233,11 +3233,11 @@
       Language: fre
       Text: "stres."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -3271,15 +3271,15 @@
       "RØalisateur" : "Eric Robin"
       Text: "Documentaire franĿais rØalisØ par Eric Robin en 2009. Des tØmoignages surprenants de personnes ayant connu une expØrience de mort imminente, un phØnomŁne qui fascine et qui divise la communautØ scientifique."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -3315,11 +3315,11 @@
       Language: fre
       Text: "Football."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3349,11 +3349,11 @@
       Language: fre
       Text: ""La Chine". Football."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3397,15 +3397,15 @@
       Language: fre
       Text: "age. La femme leur parle d'une ombre mystØrieuse."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -3452,15 +3452,15 @@
       Language: fre
       Text: "en sont Ω sa recherche, il est placØ face Ω un choix impossible."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -3501,11 +3501,11 @@
       Language: fre
       Text: "TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3535,11 +3535,11 @@
       Language: fre
       Text: "TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3569,11 +3569,11 @@
       Language: fre
       Text: "Clips."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3627,11 +3627,11 @@
       Language: fre
       Text: "ttendu."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -3666,11 +3666,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3700,11 +3700,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3735,11 +3735,11 @@
       "Direct" : "Direct"
       Text: "EN DIRECT.  1er jour. A Taŉwan."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3769,11 +3769,11 @@
       Language: fre
       Text: "4e Øtape : Escaldes-Engordany (And) - Tarragone (198,2 km)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3809,11 +3809,11 @@
       Language: fre
       Text: "ouvent leur mŁre, une femme cruelle qui leur impose une Øducation tyrannique."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -3850,15 +3850,15 @@
       Language: fre
       Text: "femmes qui peuvent lui Œtre utiles."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -3899,15 +3899,15 @@
       Language: fre
       Text: "er sur la mort de Koller. Mais Brawitsch et Gĳrnemann portent plainte contre le policier."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -3945,15 +3945,15 @@
       Language: fre
       Text: "de piŁces automobiles plonge Nadia et RovŁre dans une profonde perplexitØ."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -3985,11 +3985,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4019,11 +4019,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4059,19 +4059,19 @@
       Language: fre
       Text: "ar hollywoodienne donne lieu Ω une romance aussi inattendue que mouvementØe."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -4114,11 +4114,11 @@
       Language: fre
       Text: "i a oeuvrØ toute sa vie pour renforcer l'hØgØmonie des Habsbourg sur l'Europe."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -4148,11 +4148,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4182,11 +4182,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4216,11 +4216,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4250,11 +4250,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4290,15 +4290,15 @@
       Language: fre
       Text: " filon qui « like Ω mort » : le suicide loupØ."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -4331,15 +4331,15 @@
       "TDE" : "Supernawak"
       Text: "SØrie d'animation franĿaise. Saison 2. (n°24). "Supernawak". Les jumeaux font croire Ω Oulala, le plus maladroit des Crumpets, qu'il vient d'hØriter d'un super-pouvoir : le Grand Porte Nawak."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -4375,11 +4375,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4410,11 +4410,11 @@
       "AnnØe" : "2016"
       Text: "DIFFUSE EN HD. (-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -4445,11 +4445,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4479,11 +4479,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4514,15 +4514,15 @@
       "PrØsentateur" : "Christophe Beaugrand"
       Text: "PrØsentØ par Christophe Beaugrand. Christophe Beaugrand revient sur les reportages marquants de «Confessions intimes», les sØquences inoubliables de l'Ømission, ainsi que sur ses personnages extravagants."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -4558,15 +4558,15 @@
       Language: fre
       Text: "e de mon homme."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -4597,11 +4597,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -4638,11 +4638,11 @@
       Language: fre
       Text: "ive signØe de sa main, dØrobØe par un jeune homme avec le sac d'une passante."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -4682,11 +4682,11 @@
       "NationalitØ" : "France"
       Text: "Saison 2. "Le flageolet". Les fruits et lØgumes prennent la parole en racontant leur vie aux enfants."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+      Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4718,11 +4718,11 @@
       "TDE" : "L'hapkido"
       Text: "Les arts martiaux des mini-ninjas SØrie d'animation franĿais. Saison 1. (n°11). "L'hapkido". Le maŊtre raconte l'origine et les rŁgles de l'hapkido."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4758,11 +4758,11 @@
       Language: fre
       Text: "anniversaire surprise pour Amber."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -4797,11 +4797,11 @@
       Language: fre
       Text: "TØlØrØalitØ. "Episode 20". Un jeune homme se fait piØger en plein rencard par son meilleur ami, qui doit tout faire pour gĐcher son rendez-vous."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4837,15 +4837,15 @@
       Language: fre
       Text: " la recherche de sa vraie mŁre, une femme timide qu'elle va retrouver par hasard."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -4891,11 +4891,11 @@
       Language: fre
       Text: " bientħt que le double de son rŒve tente de la supprimer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -4931,11 +4931,11 @@
       Language: fre
       Text: "L'Ømission propose une sØlection des meilleurs produits, de l'ØlectromØnager aux cosmØtiques."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4985,11 +4985,11 @@
       Language: fre
       Text: "PrØsentØ par Jesse James. "NASCAR". Le principe : rØunir les mØcaniciens les plus incroyables, les ingØnieurs les plus extrŒmes, les plus grands innovateurs de l'automobile, dans un garage surØquipØ, et leur proposer de supers challenges."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5024,11 +5024,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5064,11 +5064,11 @@
       "TDE" : "Architectures"
       Text: "TXTCOURT."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5103,11 +5103,11 @@
       Language: fre
       Text: "toon+."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -5145,15 +5145,15 @@
       Language: fre
       Text: "ur gagner le prix du meilleur costume."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -5187,15 +5187,15 @@
       "Numero de l'Øpisode" : "6"
       Text: "Quoi de neuf, Scooby-Doo ? Saison 1. (6/14). "Vive Las Vegas". La premiŁre du spectacle d'une grande vedette est sabotØe Ω Las Vegas par un fantħme qui a connu le lointain passØ de la ville."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -5230,15 +5230,15 @@
       Language: fre
       Text: ""SpØcial Supernoobs". Mini-marathon des meilleures Øpisodes des «Supernoobs»."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -5288,15 +5288,15 @@
       Language: fre
       Text: "beau d'avoir commanditØ l'assassinat d'une stagiaire, trois ans auparavant."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -5333,15 +5333,15 @@
       Language: fre
       Text: "re se complique lorsque l'enfant des victimes, un bØbØ, est enlevØ par des inconnus."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -5372,11 +5372,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5406,11 +5406,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5440,11 +5440,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5474,11 +5474,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5514,15 +5514,15 @@
       Language: fre
       Text: ", Ω Œtre inscrite au patrimoine mondial de l'Unesco."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -5565,11 +5565,11 @@
       Language: fre
       Text: "le-GuinØe, afin de dØcouvrir de nouvelles espŁces animales et rØpertorier celles qui sont menacØes."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -5605,11 +5605,11 @@
       Language: fre
       Text: "World Series 2017. 5e manche. Epreuve dames. A Hambourg (Allemagne)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5639,11 +5639,11 @@
       Language: fre
       Text: "World Series 2017. 5e manche. Epreuve messieurs. A Hambourg (Allemagne)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5673,11 +5673,11 @@
       Language: fre
       Text: ""Sous les briques : un avenir  numØrique". A la dØcouverte des entreprises performantes de France et des hommes et des femmes qui les animent."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5707,11 +5707,11 @@
       Language: fre
       Text: "Le journal de la DØfense "OpØration Barkhane, au plus prŁs de l'armØe malienne". Entre reportages et tØmoignages, un point complet de l'actualitØ de la DØfense."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5755,11 +5755,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5790,11 +5790,11 @@
       "AnnØe" : "2015"
       Text: "(-18)  TXTCOURT."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5826,11 +5826,11 @@
       "TDE" : "Boucler la boucle"
       Text: "SØrie d'animation canadienne. Saison 1. (30/52). "Boucler la boucle". Luc et ThØo s'emparent de la station de tØlØvision de Gerry Rivers, mais cela risque d'entraŊner la fin de Port Doover et de la boucle."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5862,11 +5862,11 @@
       "TDE" : "CrĐneur"
       Text: "SØrie d'animation canadienne. Saison 1. (31/52). "CrĐneur". Luc se rase la tŒte pour ressembler Ω son idole, Cosmo Kaboum, mais en bouclant la boucle le crĐne rasØ, il provoque une anomalie."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5902,11 +5902,11 @@
       Language: fre
       Text: "ves, accompagnØes par un journaliste opposØ Ω la guerre."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -5943,11 +5943,11 @@
       Language: fre
       Text: "ode, qui accŁde pourtant au trħne en le faisant assassiner."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -5995,11 +5995,11 @@
       "PrØsentateur" : "Claire de Saint-Chamaran"
       Text: "PrØsentØ par Claire de Saint-Chamaran. Lifestyle, c'est le magazine quotidien sur les derniŁres tendances mode, beautØ, dØco, voyage et bien-Œtre prØsentØ par Claire de Saint Chamaran."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6029,11 +6029,11 @@
       Language: fre
       Text: "Des histoires, des news, des cØlØbritØs. Pour tout savoir sur l'actualitØ des stars en France et partout dans le  monde."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6069,11 +6069,11 @@
       Language: fre
       Text: "ous."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6109,11 +6109,11 @@
       Language: fre
       Text: " ses comptes."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6148,11 +6148,11 @@
       Language: fre
       Text: "io, les FranĿais auront des ambitions plus limitØes. Mais Kevin Staut, n°3 mondial et quelques autres couples performants peuvent briller."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6187,11 +6187,11 @@
       Language: fre
       Text: " Allemands se prØsenteront comme les grands favoris. La France aura des ambitions plus modestes avec de nouveaux couples."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -6228,15 +6228,15 @@
       Language: fre
       Text: "vain, prØsente Ω son infirmiŁre son livre, qui raconte l'histoire de sa vie."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: gle
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0311 (DVB subtitles, 4:3 aspect ratio)
+      Content/type: 0xF311 (DVB subtitles, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -6273,15 +6273,15 @@
       Language: fre
       Text: "possession."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: spa
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0311 (DVB subtitles, 4:3 aspect ratio)
+      Content/type: 0xF311 (DVB subtitles, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -6313,11 +6313,11 @@
       "PrØsentateur" : "ClØmence de La Baume"
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6348,11 +6348,11 @@
       "PrØsentateur" : "ClØmence de La Baume"
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6407,15 +6407,15 @@
       Language: fre
       Text: "r Ω un concours : l'homme qui arrivera Ω le vaincre gagnera un superbe prix."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -6461,15 +6461,15 @@
       Language: fre
       Text: "rouvant pas du tout cette relation, Nellie envisage de fuguer avec le jeune homme et de se marier."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -6513,11 +6513,11 @@
       "InterprŁte" : "Pascal LØgitimus"
       Text: "DIFFUSE EN HD.  Pascal LØgitimus : Alone Man Show Spectacle. Humour. Avec Pascal LØgitimus. EnregistrØ Ω Bobino, Ω Paris, le 30 mai 2015. Mise en scŁne de Gil Galliot."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -6553,11 +6553,11 @@
       Language: fre
       Text: "s arts du spectacle."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -6595,11 +6595,11 @@
       "TDE" : "Les justiciers masquØs"
       Text: "SØrie d'animation franĿaise. Saison 2. (9/26). "Les justiciers masquØs". Jay et Rekkit dØcident d'utiliser la magie pour lutter contre la criminalitØ et se transforment en un duo de pourfendeurs masquØs."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6643,11 +6643,11 @@
       Language: fre
       Text: " Boucan-Les-Bains."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6690,15 +6690,15 @@
       Language: fre
       Text: "et un film."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -6750,15 +6750,15 @@
       "TDE" : "Le larbin"
       Text: "SØrie d'animation amØricaine. Saison 1. (21/26). "Le larbin". Finn devient le nouveau larbin de Marceline : il l'embarque avec elle et son armØe de squelettes et le contraint de faire le mal partout oø il passe."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6798,15 +6798,15 @@
       "Numero de l'Øpisode" : "9"
       Text: "Saison 2. (n°9). "Les inventions de Gwen". Sofia rencontre Gwen, une jeune cuisiniŁre qui invente des ustensiles de cuisine. Sofia encourage vivement Gwen Ω poursuivre ses crØations."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6838,15 +6838,15 @@
       "TDE" : "Le dragon ØgratignØ"
       Text: "SØrie d'animation amØricaine. Saison 3. "Le dragon ØgratignØ". Toufy s'Øgratigne le ventre au cours d'une partie de ping-pong contre Hallie."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6881,11 +6881,11 @@
       Language: fre
       Text: "re Vermeil», de Montserrat. RØalisation d'Olivier Simonnet."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6926,11 +6926,11 @@
       Language: fre
       Text: "a de nos jours : histoire musicale de la tØlØvision."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6965,11 +6965,11 @@
       Language: fre
       Text: "Aventures peu banales ou expØriences partagØes par de nombreuses personnes, «Tellement vrai» s'intØresse Ω quatre destins."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6999,11 +6999,11 @@
       Language: fre
       Text: "Aventures peu banales ou expØriences partagØes par de nombreuses personnes, «Tellement vrai» s'intØresse Ω quatre destins."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7033,11 +7033,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7067,11 +7067,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7101,11 +7101,11 @@
       Language: fre
       Text: "Nancy (L2) / OrlØans (L2) Coupe de la Ligue. 2e tour."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7135,11 +7135,11 @@
       Language: fre
       Text: "Tours (L2) / Le Havre (L2) Coupe de la Ligue. 2e tour."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7169,11 +7169,11 @@
       Language: fre
       Text: "NFL. PrØsaison. 2e journØe. New York Giants / Cleveland Browns."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7211,11 +7211,11 @@
       Language: fre
       Text: "Major League Baseball 2017. Pittsburgh Pirates / St Louis Cardinals. Les St Louis Cardinals, qui avaient brillØ la saison derniŁre, se retrouvent un peu en milieu de classement de la National League, dans la partie centrale de leur championnat."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7250,11 +7250,11 @@
       Language: fre
       Text: "JT sport."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7284,11 +7284,11 @@
       Language: fre
       Text: "EN DIRECT.  Journal en langue des signes JT sport."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7319,11 +7319,11 @@
       "Numero de l'Øpisode" : "32"
       Text: "Eh les hommes eh les femmes SØrie humoristique. (n°32)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7354,11 +7354,11 @@
       "Numero de l'Øpisode" : "132"
       Text: "SØrie sentimentale. (n°132)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8042,11 +8042,11 @@
       Language: fre
       Text: "re Vermeil», de Montserrat. RØalisation d'Olivier Simonnet."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8087,11 +8087,11 @@
       Language: fre
       Text: "a de nos jours : histoire musicale de la tØlØvision."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8132,15 +8132,15 @@
       Language: fre
       Text: "e enquŒte sur l'ambassadeur du Belize, suspect dans une affaire de meurtre."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -8182,15 +8182,15 @@
       Language: fre
       Text: "a brigade fluviale, maŊtresse d'un policier retrouvØ mort Ω son tour."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -8231,11 +8231,11 @@
       "Numero de l'Øpisode" : "34"
       Text: "Saison 1. (34/52). "Les nouveaux hommes du monde". Benjamin et le docteur Robson reviennent d'Angleterre. Bertini leur apprend qu'Erik n'est pas sØlectionnØ dans l'Øquipe scandinave."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8276,11 +8276,11 @@
       Language: fre
       Text: "d'Œtre Ω l'origine de ces remous."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8315,11 +8315,11 @@
       Language: fre
       Text: "Un point sur l'actualitØ dans le monde et en Belgique par la rØdaction de la RTBF."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8355,11 +8355,11 @@
       Language: fre
       Text: "olice est amenØ Ω tenter de rØsoudre une Øtrange affaire de meurtre."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8390,11 +8390,11 @@
       "PrØsentateur" : "Diane Gouffrant"
       Text: "PrØsentØ par Diane Gouffrant. Tout ce qu'il faut savoir sur la biodiversitØ et la protection des espŁces animales et vØgØtales."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8424,11 +8424,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8458,11 +8458,11 @@
       Language: fre
       Text: "Clips. 100% musique, 100% clips."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8492,11 +8492,11 @@
       Language: fre
       Text: "Clips. Les tØlespectateurs ont le pouvoir! Chaque semaine rendez-vous sur www.tracerequest.com pour Ølire vos 15 chansons prØfØrØes et faites apparaitre vos tweets en LIVE Ω l'antenne avec le"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8527,11 +8527,11 @@
       "AnnØe" : "2016"
       Text: "Documentaire franĿais rØalisØ en 2016 (Ep. 3). "Colombie". Loin des clichØs, la Colombie affiche l'un des taux de croissance les plus forts d'AmØrique Latine ; visite d'un pays dotØ d'une variØtØ de paysages insoupĿonnØe."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8575,11 +8575,11 @@
       Language: fre
       Text: "e minute."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8609,11 +8609,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8643,11 +8643,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8677,11 +8677,11 @@
       Language: fre
       Text: "Clips. "Le meilleur des hits sur RFM". Une Ømission 100% clips, 100% tubes pour avoir la forme toute la journØe."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8711,11 +8711,11 @@
       Language: fre
       Text: "Clips. "Le meilleur des hits sur RFM". Une Ømission 100% clips, 100% tubes pour avoir la forme toute la journØe."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8745,11 +8745,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8779,11 +8779,11 @@
       Language: fre
       Text: "(-16)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8813,11 +8813,11 @@
       Language: fre
       Text: "Clips."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8847,11 +8847,11 @@
       Language: fre
       Text: "Clips."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8881,11 +8881,11 @@
       Language: fre
       Text: "Ligue 1. 3e journØe. PremiŁre apprition pour Neymar sur la pelouse du Parc des Princes, Ω l'occasion de ce duel face Ω Toulouse. DØcisif lors de la 2e journØe, le BrØsilien devrait logiquement rØgaler les supporters du PSG."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8923,11 +8923,11 @@
       Language: fre
       Text: "Bayern Munich / Bayer Leverkusen Bundesliga. 1re journØe."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8963,19 +8963,19 @@
       Language: fre
       Text: "avec Troy. Tasha devient la coach en relooking de Crystal."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0311 (DVB subtitles, 4:3 aspect ratio)
+      Content/type: 0xF311 (DVB subtitles, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -9033,11 +9033,11 @@
       Language: fre
       Text: "Clips."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9068,11 +9068,11 @@
       "Chef d'orchestre" : "Philippe Herreweghe"
       Text: "Oratorio de Noºl de Bach Solistes : Dorothee Mields, Damien Guillon, Thomas Hobbs. InterprØtØ par le Collegium Vocale Gent. EnregistrØ au Palais des Beaux-Arts de Bruxelles en 2013."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9115,11 +9115,11 @@
       Language: fre
       Text: "z/Godowsky, Villa Lobos. RØalisation de FranĿois-RenØ Martin."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -9175,11 +9175,11 @@
       Language: fre
       Text: "iØ de lui donner de l'argent de poche. la nouvelle arrive aux oreilles de Claire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -9221,11 +9221,11 @@
       Language: fre
       Text: "affronter une Øpreuve et demande conseil auprŁs de ses amies."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -9261,11 +9261,11 @@
       Language: fre
       Text: ""L'Øcole de foot et la prØ-formation". Football."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9295,11 +9295,11 @@
       Language: fre
       Text: ""Les coulisses de Nancy / Sochaux". Football."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9354,15 +9354,15 @@
       Language: fre
       Text: "inique officiellement fermØe."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -9400,11 +9400,11 @@
       Language: fre
       Text: "t 1996, Marc Dutroux a enlevØ six filles ĐgØes de 8 Ω 19 ans, Julie, MØlissa, An, Eefje, Sabine et Laetitia, et tuØ quatre d'entre elles."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -9442,19 +9442,19 @@
       Language: fre
       Text: "n voeu le plus cher : rencontrer la princesse charmante."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -9502,19 +9502,19 @@
       Language: fre
       Text: " bar mythique lui ouvre toutes les portes."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -9550,11 +9550,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9584,11 +9584,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9618,11 +9618,11 @@
       Language: fre
       Text: "Football."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9652,11 +9652,11 @@
       Language: fre
       Text: "Championnat de France Ligue 1. 26e journØe."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9697,11 +9697,11 @@
       Language: fre
       Text: "s du mØcontentement divin : c'est la science qui a bouleversØ ces croyances."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -9738,11 +9738,11 @@
       Language: fre
       Text: ", l'Œtre humain a d'abord dß dØchiffrer les lois ØlØmentaires de la science."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -9777,11 +9777,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9816,11 +9816,11 @@
       Language: fre
       Text: "ture anglaise Ω Damas."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -9856,11 +9856,11 @@
       Language: fre
       Text: "Œme espŁce, mais lui, captif depuis des annØes."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -9896,11 +9896,11 @@
       "AnnØe" : "2015"
       Text: "Documentaire franĿais rØalisØ en 2015 (3/8). "Irlande". Antoine Auriol brave l'hiver irlandais et part Ω la rencontre des vents de l'Atlantique sur la cħte Ouest du pays, au milieu des landes, des Ŋles abandonnØes et d'un ocØan dØchainØ."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9936,11 +9936,11 @@
       "PrØsentateur" : "Nicolas Doze"
       Text: "PrØsentØ par Nicolas Doze. DØbats et controverses sur BFM Business. Faites le plein d'arguments pour la journØe avec Les Experts."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9971,11 +9971,11 @@
       "PrØsentateur" : "Emmanuel Lechypre"
       Text: "PrØsentØ par Emmanuel Lechypre. Emmanuel Lechypre prØsente le meilleur de la littØrature Øconomique avec des auteurs invitØs et les chroniqueurs de l'Ømission."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10005,11 +10005,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10039,11 +10039,11 @@
       Language: fre
       Text: "(-16)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10075,11 +10075,11 @@
       "RØalisateur" : "Gilbert Di Nino"
       Text: "TXTCOURT."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10121,11 +10121,11 @@
       "AnnØe" : "2015"
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10172,11 +10172,11 @@
       Language: fre
       Text: "Circuit europØen 2017. 4e tour. Fin. A Bad Griesbach (Allemagne)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10206,11 +10206,11 @@
       Language: fre
       Text: "Golf. PrØsentØ par Pauline Sanzey."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10254,15 +10254,15 @@
       Language: fre
       Text: "sa carriŁre en recueillant un Martien tombØ du ciel."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -10303,15 +10303,15 @@
       Language: fre
       Text: "efforce d'amadouer son futur beau-fils."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -10347,11 +10347,11 @@
       Language: fre
       Text: "images d'archives dressant le portrait de plusieurs stars du cinØma."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -10388,15 +10388,15 @@
       Language: fre
       Text: " deux aristocrates et dØlaisse l'une pour l'autre."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -10439,11 +10439,11 @@
       "NationalitØ" : "Etats-Unis"
       Text: "TXTLONG."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10474,15 +10474,15 @@
       "NationalitØ" : "Etats-Unis"
       Text: "TXTCOURT."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -10513,11 +10513,11 @@
       Language: fre
       Text: "Football. Des analyses et des commentaires des rencontres de l'Olympique de Marseille, des rediffusions des plus grands matchs de l'OM d'hier et d'aujourd'hui : toute l'actualitØ de l'OM est sur OMtv."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10547,11 +10547,11 @@
       Language: fre
       Text: "Football. Des analyses et des commentaires des rencontres de l'Olympique de Marseille, des rediffusions des plus grands matchs de l'OM d'hier et d'aujourd'hui : toute l'actualitØ de l'OM est sur OMtv."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10587,15 +10587,15 @@
       Language: fre
       Text: " de Havers et Lynley rØvŁle qu'il a en rØalitØ ØtØ assassinØ."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -10632,15 +10632,15 @@
       Language: fre
       Text: "apping et le meurtre de l'enfant illØgitime d'un Øminent membre du parlement."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -10676,11 +10676,11 @@
       Language: fre
       Text: "Clips. Dance, pop-rock, R'n'b, hip-hop, rap : «Top clip» offre une programmation Øclectique."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10710,11 +10710,11 @@
       Language: fre
       Text: "Une sØlection des meilleurs clips hip-hop du moment."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10746,11 +10746,11 @@
       "TDE" : "OpØration tigre blanc"
       Text: "Documentaire amØricain rØalisØ en 2009. "OpØration tigre blanc". Bud et Carrie prØparent, non sans mal, la salle d'opØration dans laquelle Emo, le tigre blanc, doit subir une dØlicate intervention chirurgicale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -10782,11 +10782,11 @@
       "AnnØe" : "2014"
       Text: "Documentaire belge rØalisØ en 2014  (1/6). "Nazinga". Dans le sud du Burkina Faso, le ranch Nazinga fait figure d'exception en Afrique de l'Ouest : les troupeaux d'ØlØphants ne cessent de s'agrandir."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10824,15 +10824,15 @@
       Language: fre
       Text: ""Les puces de Saint-Ouen". Une incursion dans les coulisses du marchØ aux puces de Saint-Ouen."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -10868,15 +10868,15 @@
       Language: fre
       Text: ""L'autoroute des vacances". Durant les vacances scolaires, les automobilistes pressØs de profiter du soleil et du grand air prennent possession des autoroutes franĿaises."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -10918,15 +10918,15 @@
       Language: fre
       Text: "ost-traumatique consØcutif au drame qu'elle vient de vivre."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -10968,15 +10968,15 @@
       Language: fre
       Text: "oin d'atteindre ses objectifs. Quant Ω Francesco, son attitude dØroute Barbara."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -11013,19 +11013,19 @@
       Language: fre
       Text: "eux lØsØ veut rØcupØrer son argent et enlŁve le pŁre du pilote."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+      Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+      Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
       Component tag: 0x01 (1)
       Language: chi
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -11073,15 +11073,15 @@
       Language: fre
       Text: "CIA est poursuivi par un espion qu'il a lui-mŒme formØ."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+      Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+      Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -11116,11 +11116,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11150,11 +11150,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11190,11 +11190,11 @@
       Language: fre
       Text: "ues."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -11238,11 +11238,11 @@
       Language: fre
       Text: "ement extrŒmement fragile."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -11286,11 +11286,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11320,11 +11320,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11360,19 +11360,19 @@
       Language: fre
       Text: "ey lui demande de l'aider Ω convaincre une riche veuve de faire une donation Ω l'universitØ."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -11410,19 +11410,19 @@
       Language: fre
       Text: "chizophrŁne, Moretti met tout en oeuvre pour impressionner son nouveau chef."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -11467,19 +11467,19 @@
       Language: fre
       Text: "a planŁte Solaris, y dØcouvre d'Øtranges visiteurs, sortis de ses souvenirs."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -11522,19 +11522,19 @@
       Language: fre
       Text: ". Aussi entreprend-il de partir Ω sa recherche."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -11571,11 +11571,11 @@
       Language: fre
       Text: "Sports extrŒmes."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11625,11 +11625,11 @@
       Language: fre
       Text: "Sports extrŒmes."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11685,11 +11685,11 @@
       Language: fre
       Text: "s eux."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -11737,11 +11737,11 @@
       "AnnØe" : "2015"
       Text: "Documentaire amØricain rØalisØ en 2015 (Ep. 8). "ProblŁmes de peau". DØcouverte de la naissance d'un pingouin et de son apprentissage de la nage ; rencontre ensuite avec un fennec et un chien chanteur de Nouvelle-GuinØe."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -11786,11 +11786,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11821,11 +11821,11 @@
       "AnnØe" : "2013"
       Text: "DIFFUSE EN HD. (-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -11857,11 +11857,11 @@
       "Direct" : "Direct"
       Text: "EN DIRECT.  Universiade d'ØtØ 2017. 4e jour. A Taŉwan."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11902,11 +11902,11 @@
       Language: fre
       Text: "Universiade d'ØtØ 2017. Finale par appareils. A Taŉwan."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11942,11 +11942,11 @@
       Language: fre
       Text: " Qu'est-il arrivØ au Vanuatu pour qu'il soit transformØ Ω ce point ?."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -11990,11 +11990,11 @@
       Language: fre
       Text: "n Australie. Lola confie Ω LØo qu'elle pense avoir trouvØ l'homme qu'il lui faut."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -12035,11 +12035,11 @@
       Language: fre
       Text: "EN DIRECT.  Toutes les courses depuis l'hippodrome de Saint-Malo. "RØunion de Saint-Malo". Hippisme. Mixte."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12069,11 +12069,11 @@
       Language: fre
       Text: "EN DIRECT.  Toutes les courses depuis l'hippodromede Vincennes (QuintØ+). "RØunion de Vincennes". Hippisme. Trot."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12109,15 +12109,15 @@
       Language: fre
       Text: "mal Ω se faire Ω leur condition de jeunes retraitØs. Quant Ω Manon, elle se dØvergonde."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12154,15 +12154,15 @@
       Language: fre
       Text: "r nouvelle vie, ce qui se rØvŁle plus difficile pour l'un que pour l'autre."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12193,15 +12193,15 @@
       Language: fre
       Text: "Club Europe - Tutta Serie A Football."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -12237,15 +12237,15 @@
       Language: fre
       Text: "Club Europe - Die Bulischau Football."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -12281,11 +12281,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12315,11 +12315,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12349,11 +12349,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12383,11 +12383,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12423,15 +12423,15 @@
       Language: fre
       Text: "s malgrØ lui. Plus tard, Larry rencontre Ricky  Gervais."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12469,15 +12469,15 @@
       "RØalisateur" : "Matthieu Landour"
       Text: "RØalisØ par Matthieu Landour en 2015. Avec Anthony Sonigo, Silvie Laguna, ClØmence Ansault. Court mØtrage franĿais."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -12513,11 +12513,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12547,11 +12547,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12586,15 +12586,15 @@
       Language: fre
       Text: "Ces histoires vraies sont interprØtØes par des comØdiens."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12635,15 +12635,15 @@
       Language: fre
       Text: " vraies sont interprØtØes par des comØdiens, Øcrites et rØalisØes comme un reportage."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12685,11 +12685,11 @@
       Language: fre
       Text: "croit avoir trouvØ le coupable en la personne d'un enseignant."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -12725,11 +12725,11 @@
       Language: fre
       Text: "rte au silence du corps mØdical, ce qui complique ses  recherches."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -12765,15 +12765,15 @@
       Language: fre
       Text: "Łle et tient Ω faire quelque chose d'original pour sa fŒte."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -12809,19 +12809,19 @@
       Language: fre
       Text: " soient prŒts en mŒme temps pour se rendre Ω un ØvØnement trŁs important."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -12858,19 +12858,19 @@
       Language: fre
       Text: "nØes dans les bois. Sans famille, il prØtend avoir ØtØ ØlevØ par un dragon gØant."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -12908,19 +12908,19 @@
       Language: fre
       Text: "d, Diego, Manny et leurs amis cherchent un moyen de stopper l'apocalypse imminente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -12953,11 +12953,11 @@
       "Numero de l'Øpisode" : "49"
       Text: "SØrie dramatique avec Funke Akindele, Olayode Juliana, Arike Akinyanju. (49/65). Suliat, une coiffeuse de village, dØbarque en ville pour tenter de rentrer Ω l'universitØ. Sa nouvelle vie en ville ne sera pas de tout repos."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12988,11 +12988,11 @@
       "RØalisateur" : "Femi Olusina"
       Text: "RØalisØ par Femi Olusina. Avec Feyi Adepoju, Rotimi Amodj. Drame."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13023,11 +13023,11 @@
       "PrØsentateur" : "Jean-Pierre Pernaut"
       Text: "DIFFUSE EN HD.  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 8 bytes
@@ -13059,11 +13059,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 8 bytes
@@ -13095,11 +13095,11 @@
       Language: fre
       Text: "Clips."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13129,11 +13129,11 @@
       Language: fre
       Text: "Clips."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13169,11 +13169,11 @@
       Language: fre
       Text: " roman de Pierre Loti, «Les DØsenchantØes»."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13215,15 +13215,15 @@
       Language: fre
       Text: "ation des camps, filme Ingrid Bergman et Cary Grant dans un thriller d'une rare noirceur."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -13259,11 +13259,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13293,11 +13293,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13327,11 +13327,11 @@
       Language: fre
       Text: "Clips."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13361,11 +13361,11 @@
       Language: fre
       Text: "Clips. M6 Music propose de retrouver une compilation des meilleurs clips du moment."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13395,11 +13395,11 @@
       Language: fre
       Text: "EN DIRECT.  Au sommaire : "Une semaine en..."."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13429,11 +13429,11 @@
       Language: fre
       Text: "EN DIRECT.  Au sommaire : "Une semaine en..."."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13463,11 +13463,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13497,11 +13497,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13537,11 +13537,11 @@
       Language: fre
       Text: "la Normandie : un fait historique crucial dans la libØration du pays."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13591,11 +13591,11 @@
       Language: fre
       Text: "squ'au sacrifice de la personne."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13636,11 +13636,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13670,11 +13670,11 @@
       Language: fre
       Text: "Emission du bien-Œtre. "Eat.Sleep.Surf : Taŉwan 03"."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13710,11 +13710,11 @@
       Language: fre
       Text: "l, sans prØvenir personne."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13750,11 +13750,11 @@
       Language: fre
       Text: "ncontres."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13784,11 +13784,11 @@
       Language: fre
       Text: "Championnat d'Europe 2017. 6e manche. A Kristianstad (SuŁde)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13838,11 +13838,11 @@
       Language: fre
       Text: ""Episode 6". Automobiles, motos ou machines Øtonnantes sont montØes et essayØes par les meilleurs prØparateurs de la  planŁte."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13883,11 +13883,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13917,11 +13917,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13951,11 +13951,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13985,11 +13985,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14025,15 +14025,15 @@
       Language: fre
       Text: "nt des histoires incroyables : conflits de quartier, amours interdites, mensonges, secrets ou jalousies."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -14079,11 +14079,11 @@
       Language: fre
       Text: "Une personnalitØ invite Ω dØcouvrir l'endroit oø elle rŒverait d'emmener un Œtre cher."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14119,15 +14119,15 @@
       Language: fre
       Text: "n poste situØ au plus bas de l'Øchelle."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -14164,15 +14164,15 @@
       Language: fre
       Text: " ce qui dØplaŊt fortement Ω Michael, qui lui fait connaŊtre son avis sur la question."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -14209,15 +14209,15 @@
       Language: fre
       Text: " elle se retrouve sur les bords d'une riviŁre."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -14260,15 +14260,15 @@
       Language: fre
       Text: "trouve sur les bords d'une riviŁre, prŁs d'une forŒt et d'une petite ville."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -14305,11 +14305,11 @@
       Language: fre
       Text: "The Late Late Show with James Corden Talk show. "Episode 86". James Corden reĿoit sur son plateau les personnalitØs qui font l'actualitØ amØricaine et internationale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14347,11 +14347,11 @@
       Language: fre
       Text: "Clips. Un espace musical exclusivement rØservØ aux clips. MCM propose une sØlection des tubes du moment. C'est l'occasion de dØcouvrir les derniŁres nouveautØ de la variØtØ mondiale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14387,19 +14387,19 @@
       Language: fre
       Text: "sformer leur oncle en parfait candidat."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -14436,15 +14436,15 @@
       Language: fre
       Text: " et de surmonter leurs diffØrentes peurs."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -14485,15 +14485,15 @@
       Language: fre
       Text: "riage assis devant la tØlØ, Frankie met les ZhuZhus Ω contribution pour organiser une soirØe."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -14540,15 +14540,15 @@
       Language: fre
       Text: "bien failli les asperger de son liquide malodorant."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -14589,11 +14589,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14623,11 +14623,11 @@
       Language: fre
       Text: "beIN SPORTS, le plus grand des spectacles."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14657,11 +14657,11 @@
       Language: fre
       Text: "(-18)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14691,11 +14691,11 @@
       Language: fre
       Text: "(-16)  Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14726,15 +14726,15 @@
       "PrØsentateur" : "Michel Cymes"
       Text: "Les docs du Mag de la santØ PrØsentØ par Michel Cymes, Marina CarrŁre d'Encausse. Au sommaire : "Etre mŁre au-delΩ du cancer". - "Le rallye des Gazelles"."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -14771,15 +14771,15 @@
       Language: fre
       Text: "dans l'horizon, et pour les Mormons."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -14810,11 +14810,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14846,11 +14846,11 @@
       "RØalisateur" : "StØphane Berry"
       Text: "(-18)  TXTCOURT."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14880,11 +14880,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14914,11 +14914,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14954,19 +14954,19 @@
       Language: fre
       Text: "t Beckett les conduit Ω s'intØresser Ω la mafia irlandaise de Staten Island."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -15003,19 +15003,19 @@
       Language: fre
       Text: "es jumelles pour tromper l'ennui, est tØmoin d'un meurtre."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -15048,11 +15048,11 @@
       "TDE" : "Le rival"
       Text: "SØrie jeunesse amØricaine avec Keke Palmer, Ashley Argota, Matt Shively. Saison 1. (10/26). "Le rival". Le concurrent et ennemi jurØ de Max fait les yeux doux Ω True pour qu'elle accepte de travailler pour lui."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -15088,11 +15088,11 @@
       Language: fre
       Text: "primer ses sentiments, elle se rØfugie dans la musique."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -15122,11 +15122,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -15156,11 +15156,11 @@
       Language: fre
       Text: "Information non disponible."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes

--- a/reference/test-001/test-001.tstables.text.txt
+++ b/reference/test-001/test-001.tstables.text.txt
@@ -1568,11 +1568,11 @@
         "PrØsentateur" : "Julien Desvages"
         Text: "EN DIRECT.  TXT0."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -1601,11 +1601,11 @@
         "PrØsentateur" : "Julien Desvages"
         Text: "EN DIRECT.  TXT0."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -1636,11 +1636,11 @@
         Language: fre
         Text: "DIFFUSE EN HD.  Gant d'Or 2017. Finale. A Biarritz (PyrØnØes-Atlantiques)."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1669,11 +1669,11 @@
         Language: fre
         Text: "DIFFUSE EN HD.  Lorient (L2) / Lens (L2) Coupe de la Ligue. 2e tour."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1716,19 +1716,19 @@
         Language: fre
         Text: "n chien. Il s'en dØbarrasse rapidement. Pris de remords, il dØcide de l'aider."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -1769,15 +1769,15 @@
         Language: fre
         Text: "DIFFUSE EN HD.  "EtØ 2011". Avec l'humour et la tchatche qui le caractØrisent, Kamel, intervenant rØgulier du «Grand Journal», propose des tours de magie rØalisØs dans des lieux insolites."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -1821,19 +1821,19 @@
         Language: fre
         Text: "nØes dans les bois. Sans famille, il prØtend avoir ØtØ ØlevØ par un dragon gØant."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -1869,19 +1869,19 @@
         Language: fre
         Text: "d, Diego, Manny et leurs amis cherchent un moyen de stopper l'apocalypse imminente."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -1920,15 +1920,15 @@
         Language: fre
         Text: "ir afin de pouvoir combattre un cruel ennemi qui menace le monde des humains."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -1972,15 +1972,15 @@
         Language: fre
         Text: "it Prince."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -2086,15 +2086,15 @@
         Language: fre
         Text: "obile."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -2130,15 +2130,15 @@
         Language: fre
         Text: "le but de percer le secret de la subtile «nihon ryħri», la cuisine nippone."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -2182,19 +2182,19 @@
         Language: fre
         Text: "tour au commissariat. Amy s'interroge sur les longues pauses effectuØes par Rosa."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -2237,19 +2237,19 @@
         Language: fre
         Text: "ets au sein du commissariat. Chacun se dØmŁne pour avoir le trophØe en jeu."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -2295,15 +2295,15 @@
         Language: fre
         Text: "s connu. Il se rend Ω MontrØal afin d'en savoir plus sur lui."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -2343,15 +2343,15 @@
         Language: fre
         Text: "rise de remords, la praticienne dØcide d'enquŒter sur l'inconnue."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -2409,19 +2409,19 @@
         Language: fre
         Text: "d'arrŒter un soldat sudiste qui a massacrØ sa famille."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -2465,19 +2465,19 @@
         Language: fre
         Text: "pour fournir au FBI les preuves nØcessaires Ω un Øventuel procŁs."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -2521,19 +2521,19 @@
         Language: fre
         Text: "contre une jeune hØritiŁre extravagante et son gentil lØopard."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -2580,19 +2580,19 @@
         Language: fre
         Text: "idieusement dans l'intimitØ d'une vedette de thØĐtre sur le dØclin."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -2630,11 +2630,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -2662,11 +2662,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -2703,11 +2703,11 @@
         Language: fre
         Text: "lise. Elle peut organiser un grand festival des animaux."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -2742,11 +2742,11 @@
         Language: fre
         Text: "er les idØes, Peter Pan organise une chasse au trØsor sur Neverland.."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -2784,15 +2784,15 @@
         Language: fre
         Text: "le amitiØ, qui se transforme ensuite en un amour vØritable : un conte de fØe."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -2827,15 +2827,15 @@
         Language: fre
         Text: "re, dØcouvre et dØnonce les manigances de la future prØsidente."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -2867,11 +2867,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -2919,11 +2919,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -2980,15 +2980,15 @@
         Language: fre
         Text: "pprocher le plus prŁs possible."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -3023,15 +3023,15 @@
         Language: fre
         Text: "a taille d'un homme : le poisson-chat."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -3063,11 +3063,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3095,11 +3095,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3136,11 +3136,11 @@
         Language: fre
         Text: "prŁs de 1% de la population du monde occidental."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -3180,11 +3180,11 @@
         "PrØsentateur" : "JØrħme Bonaldi"
         Text: "Le mag de la science : hebdo PrØsentØ par JØrħme Bonaldi. Au sommaire : "Pirogue en Picardie". - "Le caoutchouc". - "Le latex". - "Le camØlØon"."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3228,11 +3228,11 @@
         Language: fre
         Text: "stres."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -3264,15 +3264,15 @@
         "RØalisateur" : "Eric Robin"
         Text: "Documentaire franĿais rØalisØ par Eric Robin en 2009. Des tØmoignages surprenants de personnes ayant connu une expØrience de mort imminente, un phØnomŁne qui fascine et qui divise la communautØ scientifique."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -3309,11 +3309,11 @@
         Language: fre
         Text: "Football."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3341,11 +3341,11 @@
         Language: fre
         Text: ""La Chine". Football."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3390,15 +3390,15 @@
         Language: fre
         Text: "age. La femme leur parle d'une ombre mystØrieuse."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -3443,15 +3443,15 @@
         Language: fre
         Text: "en sont Ω sa recherche, il est placØ face Ω un choix impossible."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -3493,11 +3493,11 @@
         Language: fre
         Text: "TXT0."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3525,11 +3525,11 @@
         Language: fre
         Text: "TXT0."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3560,11 +3560,11 @@
         Language: fre
         Text: "Clips."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3616,11 +3616,11 @@
         Language: fre
         Text: "ttendu."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -3656,11 +3656,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3688,11 +3688,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3724,11 +3724,11 @@
         "Direct" : "Direct"
         Text: "EN DIRECT.  1er jour. A Taŉwan."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3756,11 +3756,11 @@
         Language: fre
         Text: "4e Øtape : Escaldes-Engordany (And) - Tarragone (198,2 km)."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3797,11 +3797,11 @@
         Language: fre
         Text: "ouvent leur mŁre, une femme cruelle qui leur impose une Øducation tyrannique."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -3836,15 +3836,15 @@
         Language: fre
         Text: "femmes qui peuvent lui Œtre utiles."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -3886,15 +3886,15 @@
         Language: fre
         Text: "er sur la mort de Koller. Mais Brawitsch et Gĳrnemann portent plainte contre le policier."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -3930,15 +3930,15 @@
         Language: fre
         Text: "de piŁces automobiles plonge Nadia et RovŁre dans une profonde perplexitØ."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -3971,11 +3971,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4003,11 +4003,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4044,19 +4044,19 @@
         Language: fre
         Text: "ar hollywoodienne donne lieu Ω une romance aussi inattendue que mouvementØe."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -4097,11 +4097,11 @@
         Language: fre
         Text: "i a oeuvrØ toute sa vie pour renforcer l'hØgØmonie des Habsbourg sur l'Europe."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -4132,11 +4132,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4164,11 +4164,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4199,11 +4199,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4231,11 +4231,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4272,15 +4272,15 @@
         Language: fre
         Text: " filon qui « like Ω mort » : le suicide loupØ."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -4311,15 +4311,15 @@
         "TDE" : "Supernawak"
         Text: "SØrie d'animation franĿaise. Saison 2. (n°24). "Supernawak". Les jumeaux font croire Ω Oulala, le plus maladroit des Crumpets, qu'il vient d'hØriter d'un super-pouvoir : le Grand Porte Nawak."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -4356,11 +4356,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4389,11 +4389,11 @@
         "AnnØe" : "2016"
         Text: "DIFFUSE EN HD. (-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -4425,11 +4425,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4457,11 +4457,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4493,15 +4493,15 @@
         "PrØsentateur" : "Christophe Beaugrand"
         Text: "PrØsentØ par Christophe Beaugrand. Christophe Beaugrand revient sur les reportages marquants de «Confessions intimes», les sØquences inoubliables de l'Ømission, ainsi que sur ses personnages extravagants."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -4535,15 +4535,15 @@
         Language: fre
         Text: "e de mon homme."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -4575,11 +4575,11 @@
         Language: fre
         Text: "DIFFUSE EN HD.  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -4614,11 +4614,11 @@
         Language: fre
         Text: "ive signØe de sa main, dØrobØe par un jeune homme avec le sac d'une passante."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -4659,11 +4659,11 @@
         "NationalitØ" : "France"
         Text: "Saison 2. "Le flageolet". Les fruits et lØgumes prennent la parole en racontant leur vie aux enfants."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+        Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4693,11 +4693,11 @@
         "TDE" : "L'hapkido"
         Text: "Les arts martiaux des mini-ninjas SØrie d'animation franĿais. Saison 1. (n°11). "L'hapkido". Le maŊtre raconte l'origine et les rŁgles de l'hapkido."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4734,11 +4734,11 @@
         Language: fre
         Text: "anniversaire surprise pour Amber."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -4771,11 +4771,11 @@
         Language: fre
         Text: "TØlØrØalitØ. "Episode 20". Un jeune homme se fait piØger en plein rencard par son meilleur ami, qui doit tout faire pour gĐcher son rendez-vous."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4812,15 +4812,15 @@
         Language: fre
         Text: " la recherche de sa vraie mŁre, une femme timide qu'elle va retrouver par hasard."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -4864,11 +4864,11 @@
         Language: fre
         Text: " bientħt que le double de son rŒve tente de la supprimer."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -4905,11 +4905,11 @@
         Language: fre
         Text: "L'Ømission propose une sØlection des meilleurs produits, de l'ØlectromØnager aux cosmØtiques."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4957,11 +4957,11 @@
         Language: fre
         Text: "PrØsentØ par Jesse James. "NASCAR". Le principe : rØunir les mØcaniciens les plus incroyables, les ingØnieurs les plus extrŒmes, les plus grands innovateurs de l'automobile, dans un garage surØquipØ, et leur proposer de supers challenges."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -4997,11 +4997,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5035,11 +5035,11 @@
         "TDE" : "Architectures"
         Text: "TXTCOURT."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5075,11 +5075,11 @@
         Language: fre
         Text: "toon+."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -5115,15 +5115,15 @@
         Language: fre
         Text: "ur gagner le prix du meilleur costume."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -5158,15 +5158,15 @@
         "Numero de l'Øpisode" : "6"
         Text: "Quoi de neuf, Scooby-Doo ? Saison 1. (6/14). "Vive Las Vegas". La premiŁre du spectacle d'une grande vedette est sabotØe Ω Las Vegas par un fantħme qui a connu le lointain passØ de la ville."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -5199,15 +5199,15 @@
         Language: fre
         Text: ""SpØcial Supernoobs". Mini-marathon des meilleures Øpisodes des «Supernoobs»."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -5258,15 +5258,15 @@
         Language: fre
         Text: "beau d'avoir commanditØ l'assassinat d'une stagiaire, trois ans auparavant."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -5301,15 +5301,15 @@
         Language: fre
         Text: "re se complique lorsque l'enfant des victimes, un bØbØ, est enlevØ par des inconnus."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -5341,11 +5341,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5373,11 +5373,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5408,11 +5408,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5440,11 +5440,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5481,15 +5481,15 @@
         Language: fre
         Text: ", Ω Œtre inscrite au patrimoine mondial de l'Unesco."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -5530,11 +5530,11 @@
         Language: fre
         Text: "le-GuinØe, afin de dØcouvrir de nouvelles espŁces animales et rØpertorier celles qui sont menacØes."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -5571,11 +5571,11 @@
         Language: fre
         Text: "World Series 2017. 5e manche. Epreuve dames. A Hambourg (Allemagne)."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5603,11 +5603,11 @@
         Language: fre
         Text: "World Series 2017. 5e manche. Epreuve messieurs. A Hambourg (Allemagne)."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5638,11 +5638,11 @@
         Language: fre
         Text: ""Sous les briques : un avenir  numØrique". A la dØcouverte des entreprises performantes de France et des hommes et des femmes qui les animent."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5670,11 +5670,11 @@
         Language: fre
         Text: "Le journal de la DØfense "OpØration Barkhane, au plus prŁs de l'armØe malienne". Entre reportages et tØmoignages, un point complet de l'actualitØ de la DØfense."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5719,11 +5719,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5752,11 +5752,11 @@
         "AnnØe" : "2015"
         Text: "(-18)  TXTCOURT."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5789,11 +5789,11 @@
         "TDE" : "Boucler la boucle"
         Text: "SØrie d'animation canadienne. Saison 1. (30/52). "Boucler la boucle". Luc et ThØo s'emparent de la station de tØlØvision de Gerry Rivers, mais cela risque d'entraŊner la fin de Port Doover et de la boucle."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5823,11 +5823,11 @@
         "TDE" : "CrĐneur"
         Text: "SØrie d'animation canadienne. Saison 1. (31/52). "CrĐneur". Luc se rase la tŒte pour ressembler Ω son idole, Cosmo Kaboum, mais en bouclant la boucle le crĐne rasØ, il provoque une anomalie."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5864,11 +5864,11 @@
         Language: fre
         Text: "ves, accompagnØes par un journaliste opposØ Ω la guerre."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -5903,11 +5903,11 @@
         Language: fre
         Text: "ode, qui accŁde pourtant au trħne en le faisant assassiner."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -5956,11 +5956,11 @@
         "PrØsentateur" : "Claire de Saint-Chamaran"
         Text: "PrØsentØ par Claire de Saint-Chamaran. Lifestyle, c'est le magazine quotidien sur les derniŁres tendances mode, beautØ, dØco, voyage et bien-Œtre prØsentØ par Claire de Saint Chamaran."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5988,11 +5988,11 @@
         Language: fre
         Text: "Des histoires, des news, des cØlØbritØs. Pour tout savoir sur l'actualitØ des stars en France et partout dans le  monde."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6029,11 +6029,11 @@
         Language: fre
         Text: "ous."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6067,11 +6067,11 @@
         Language: fre
         Text: " ses comptes."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6107,11 +6107,11 @@
         Language: fre
         Text: "io, les FranĿais auront des ambitions plus limitØes. Mais Kevin Staut, n°3 mondial et quelques autres couples performants peuvent briller."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6144,11 +6144,11 @@
         Language: fre
         Text: " Allemands se prØsenteront comme les grands favoris. La France aura des ambitions plus modestes avec de nouveaux couples."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -6186,15 +6186,15 @@
         Language: fre
         Text: "vain, prØsente Ω son infirmiŁre son livre, qui raconte l'histoire de sa vie."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: gle
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0311 (DVB subtitles, 4:3 aspect ratio)
+        Content/type: 0xF311 (DVB subtitles, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -6229,15 +6229,15 @@
         Language: fre
         Text: "possession."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: spa
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0311 (DVB subtitles, 4:3 aspect ratio)
+        Content/type: 0xF311 (DVB subtitles, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -6270,11 +6270,11 @@
         "PrØsentateur" : "ClØmence de La Baume"
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6303,11 +6303,11 @@
         "PrØsentateur" : "ClØmence de La Baume"
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6364,15 +6364,15 @@
         Language: fre
         Text: "r Ω un concours : l'homme qui arrivera Ω le vaincre gagnera un superbe prix."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -6416,15 +6416,15 @@
         Language: fre
         Text: "rouvant pas du tout cette relation, Nellie envisage de fuguer avec le jeune homme et de se marier."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -6469,11 +6469,11 @@
         "InterprŁte" : "Pascal LØgitimus"
         Text: "DIFFUSE EN HD.  Pascal LØgitimus : Alone Man Show Spectacle. Humour. Avec Pascal LØgitimus. EnregistrØ Ω Bobino, Ω Paris, le 30 mai 2015. Mise en scŁne de Gil Galliot."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -6507,11 +6507,11 @@
         Language: fre
         Text: "s arts du spectacle."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -6550,11 +6550,11 @@
         "TDE" : "Les justiciers masquØs"
         Text: "SØrie d'animation franĿaise. Saison 2. (9/26). "Les justiciers masquØs". Jay et Rekkit dØcident d'utiliser la magie pour lutter contre la criminalitØ et se transforment en un duo de pourfendeurs masquØs."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6596,11 +6596,11 @@
         Language: fre
         Text: " Boucan-Les-Bains."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6644,15 +6644,15 @@
         Language: fre
         Text: "et un film."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -6702,15 +6702,15 @@
         "TDE" : "Le larbin"
         Text: "SØrie d'animation amØricaine. Saison 1. (21/26). "Le larbin". Finn devient le nouveau larbin de Marceline : il l'embarque avec elle et son armØe de squelettes et le contraint de faire le mal partout oø il passe."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6751,15 +6751,15 @@
         "Numero de l'Øpisode" : "9"
         Text: "Saison 2. (n°9). "Les inventions de Gwen". Sofia rencontre Gwen, une jeune cuisiniŁre qui invente des ustensiles de cuisine. Sofia encourage vivement Gwen Ω poursuivre ses crØations."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6789,15 +6789,15 @@
         "TDE" : "Le dragon ØgratignØ"
         Text: "SØrie d'animation amØricaine. Saison 3. "Le dragon ØgratignØ". Toufy s'Øgratigne le ventre au cours d'une partie de ping-pong contre Hallie."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6833,11 +6833,11 @@
         Language: fre
         Text: "re Vermeil», de Montserrat. RØalisation d'Olivier Simonnet."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6876,11 +6876,11 @@
         Language: fre
         Text: "a de nos jours : histoire musicale de la tØlØvision."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -6916,11 +6916,11 @@
         Language: fre
         Text: "Aventures peu banales ou expØriences partagØes par de nombreuses personnes, «Tellement vrai» s'intØresse Ω quatre destins."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6948,11 +6948,11 @@
         Language: fre
         Text: "Aventures peu banales ou expØriences partagØes par de nombreuses personnes, «Tellement vrai» s'intØresse Ω quatre destins."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -6983,11 +6983,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7015,11 +7015,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7050,11 +7050,11 @@
         Language: fre
         Text: "Nancy (L2) / OrlØans (L2) Coupe de la Ligue. 2e tour."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7082,11 +7082,11 @@
         Language: fre
         Text: "Tours (L2) / Le Havre (L2) Coupe de la Ligue. 2e tour."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7117,11 +7117,11 @@
         Language: fre
         Text: "NFL. PrØsaison. 2e journØe. New York Giants / Cleveland Browns."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7157,11 +7157,11 @@
         Language: fre
         Text: "Major League Baseball 2017. Pittsburgh Pirates / St Louis Cardinals. Les St Louis Cardinals, qui avaient brillØ la saison derniŁre, se retrouvent un peu en milieu de classement de la National League, dans la partie centrale de leur championnat."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7197,11 +7197,11 @@
         Language: fre
         Text: "JT sport."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7229,11 +7229,11 @@
         Language: fre
         Text: "EN DIRECT.  Journal en langue des signes JT sport."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7265,11 +7265,11 @@
         "Numero de l'Øpisode" : "32"
         Text: "Eh les hommes eh les femmes SØrie humoristique. (n°32)."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7298,11 +7298,11 @@
         "Numero de l'Øpisode" : "132"
         Text: "SØrie sentimentale. (n°132)."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8020,11 +8020,11 @@
         Language: fre
         Text: "re Vermeil», de Montserrat. RØalisation d'Olivier Simonnet."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8063,11 +8063,11 @@
         Language: fre
         Text: "a de nos jours : histoire musicale de la tØlØvision."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8109,15 +8109,15 @@
         Language: fre
         Text: "e enquŒte sur l'ambassadeur du Belize, suspect dans une affaire de meurtre."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -8157,15 +8157,15 @@
         Language: fre
         Text: "a brigade fluviale, maŊtresse d'un policier retrouvØ mort Ω son tour."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -8207,11 +8207,11 @@
         "Numero de l'Øpisode" : "34"
         Text: "Saison 1. (34/52). "Les nouveaux hommes du monde". Benjamin et le docteur Robson reviennent d'Angleterre. Bertini leur apprend qu'Erik n'est pas sØlectionnØ dans l'Øquipe scandinave."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8250,11 +8250,11 @@
         Language: fre
         Text: "d'Œtre Ω l'origine de ces remous."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8290,11 +8290,11 @@
         Language: fre
         Text: "Un point sur l'actualitØ dans le monde et en Belgique par la rØdaction de la RTBF."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8328,11 +8328,11 @@
         Language: fre
         Text: "olice est amenØ Ω tenter de rØsoudre une Øtrange affaire de meurtre."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8364,11 +8364,11 @@
         "PrØsentateur" : "Diane Gouffrant"
         Text: "PrØsentØ par Diane Gouffrant. Tout ce qu'il faut savoir sur la biodiversitØ et la protection des espŁces animales et vØgØtales."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8396,11 +8396,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8431,11 +8431,11 @@
         Language: fre
         Text: "Clips. 100% musique, 100% clips."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8463,11 +8463,11 @@
         Language: fre
         Text: "Clips. Les tØlespectateurs ont le pouvoir! Chaque semaine rendez-vous sur www.tracerequest.com pour Ølire vos 15 chansons prØfØrØes et faites apparaitre vos tweets en LIVE Ω l'antenne avec le"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8499,11 +8499,11 @@
         "AnnØe" : "2016"
         Text: "Documentaire franĿais rØalisØ en 2016 (Ep. 3). "Colombie". Loin des clichØs, la Colombie affiche l'un des taux de croissance les plus forts d'AmØrique Latine ; visite d'un pays dotØ d'une variØtØ de paysages insoupĿonnØe."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8545,11 +8545,11 @@
         Language: fre
         Text: "e minute."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -8580,11 +8580,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8612,11 +8612,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8647,11 +8647,11 @@
         Language: fre
         Text: "Clips. "Le meilleur des hits sur RFM". Une Ømission 100% clips, 100% tubes pour avoir la forme toute la journØe."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8679,11 +8679,11 @@
         Language: fre
         Text: "Clips. "Le meilleur des hits sur RFM". Une Ømission 100% clips, 100% tubes pour avoir la forme toute la journØe."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8714,11 +8714,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8746,11 +8746,11 @@
         Language: fre
         Text: "(-16)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8781,11 +8781,11 @@
         Language: fre
         Text: "Clips."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8813,11 +8813,11 @@
         Language: fre
         Text: "Clips."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8848,11 +8848,11 @@
         Language: fre
         Text: "Ligue 1. 3e journØe. PremiŁre apprition pour Neymar sur la pelouse du Parc des Princes, Ω l'occasion de ce duel face Ω Toulouse. DØcisif lors de la 2e journØe, le BrØsilien devrait logiquement rØgaler les supporters du PSG."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8888,11 +8888,11 @@
         Language: fre
         Text: "Bayern Munich / Bayer Leverkusen Bundesliga. 1re journØe."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -8929,19 +8929,19 @@
         Language: fre
         Text: "avec Troy. Tasha devient la coach en relooking de Crystal."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0311 (DVB subtitles, 4:3 aspect ratio)
+        Content/type: 0xF311 (DVB subtitles, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -8997,11 +8997,11 @@
         Language: fre
         Text: "Clips."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9033,11 +9033,11 @@
         "Chef d'orchestre" : "Philippe Herreweghe"
         Text: "Oratorio de Noºl de Bach Solistes : Dorothee Mields, Damien Guillon, Thomas Hobbs. InterprØtØ par le Collegium Vocale Gent. EnregistrØ au Palais des Beaux-Arts de Bruxelles en 2013."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9078,11 +9078,11 @@
         Language: fre
         Text: "z/Godowsky, Villa Lobos. RØalisation de FranĿois-RenØ Martin."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -9139,11 +9139,11 @@
         Language: fre
         Text: "iØ de lui donner de l'argent de poche. la nouvelle arrive aux oreilles de Claire."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -9183,11 +9183,11 @@
         Language: fre
         Text: "affronter une Øpreuve et demande conseil auprŁs de ses amies."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -9224,11 +9224,11 @@
         Language: fre
         Text: ""L'Øcole de foot et la prØ-formation". Football."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9256,11 +9256,11 @@
         Language: fre
         Text: ""Les coulisses de Nancy / Sochaux". Football."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9316,15 +9316,15 @@
         Language: fre
         Text: "inique officiellement fermØe."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -9360,11 +9360,11 @@
         Language: fre
         Text: "t 1996, Marc Dutroux a enlevØ six filles ĐgØes de 8 Ω 19 ans, Julie, MØlissa, An, Eefje, Sabine et Laetitia, et tuØ quatre d'entre elles."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -9403,19 +9403,19 @@
         Language: fre
         Text: "n voeu le plus cher : rencontrer la princesse charmante."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -9461,19 +9461,19 @@
         Language: fre
         Text: " bar mythique lui ouvre toutes les portes."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -9510,11 +9510,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9542,11 +9542,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9577,11 +9577,11 @@
         Language: fre
         Text: "Football."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9609,11 +9609,11 @@
         Language: fre
         Text: "Championnat de France Ligue 1. 26e journØe."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9655,11 +9655,11 @@
         Language: fre
         Text: "s du mØcontentement divin : c'est la science qui a bouleversØ ces croyances."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -9694,11 +9694,11 @@
         Language: fre
         Text: ", l'Œtre humain a d'abord dß dØchiffrer les lois ØlØmentaires de la science."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -9734,11 +9734,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9771,11 +9771,11 @@
         Language: fre
         Text: "ture anglaise Ω Damas."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -9812,11 +9812,11 @@
         Language: fre
         Text: "Œme espŁce, mais lui, captif depuis des annØes."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -9850,11 +9850,11 @@
         "AnnØe" : "2015"
         Text: "Documentaire franĿais rØalisØ en 2015 (3/8). "Irlande". Antoine Auriol brave l'hiver irlandais et part Ω la rencontre des vents de l'Atlantique sur la cħte Ouest du pays, au milieu des landes, des Ŋles abandonnØes et d'un ocØan dØchainØ."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9891,11 +9891,11 @@
         "PrØsentateur" : "Nicolas Doze"
         Text: "PrØsentØ par Nicolas Doze. DØbats et controverses sur BFM Business. Faites le plein d'arguments pour la journØe avec Les Experts."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9924,11 +9924,11 @@
         "PrØsentateur" : "Emmanuel Lechypre"
         Text: "PrØsentØ par Emmanuel Lechypre. Emmanuel Lechypre prØsente le meilleur de la littØrature Øconomique avec des auteurs invitØs et les chroniqueurs de l'Ømission."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9959,11 +9959,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9991,11 +9991,11 @@
         Language: fre
         Text: "(-16)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10028,11 +10028,11 @@
         "RØalisateur" : "Gilbert Di Nino"
         Text: "TXTCOURT."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10072,11 +10072,11 @@
         "AnnØe" : "2015"
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10124,11 +10124,11 @@
         Language: fre
         Text: "Circuit europØen 2017. 4e tour. Fin. A Bad Griesbach (Allemagne)."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10156,11 +10156,11 @@
         Language: fre
         Text: "Golf. PrØsentØ par Pauline Sanzey."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10205,15 +10205,15 @@
         Language: fre
         Text: "sa carriŁre en recueillant un Martien tombØ du ciel."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -10252,15 +10252,15 @@
         Language: fre
         Text: "efforce d'amadouer son futur beau-fils."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -10297,11 +10297,11 @@
         Language: fre
         Text: "images d'archives dressant le portrait de plusieurs stars du cinØma."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -10336,15 +10336,15 @@
         Language: fre
         Text: " deux aristocrates et dØlaisse l'une pour l'autre."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -10388,11 +10388,11 @@
         "NationalitØ" : "Etats-Unis"
         Text: "TXTLONG."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10421,15 +10421,15 @@
         "NationalitØ" : "Etats-Unis"
         Text: "TXTCOURT."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -10461,11 +10461,11 @@
         Language: fre
         Text: "Football. Des analyses et des commentaires des rencontres de l'Olympique de Marseille, des rediffusions des plus grands matchs de l'OM d'hier et d'aujourd'hui : toute l'actualitØ de l'OM est sur OMtv."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10493,11 +10493,11 @@
         Language: fre
         Text: "Football. Des analyses et des commentaires des rencontres de l'Olympique de Marseille, des rediffusions des plus grands matchs de l'OM d'hier et d'aujourd'hui : toute l'actualitØ de l'OM est sur OMtv."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10534,15 +10534,15 @@
         Language: fre
         Text: " de Havers et Lynley rØvŁle qu'il a en rØalitØ ØtØ assassinØ."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -10577,15 +10577,15 @@
         Language: fre
         Text: "apping et le meurtre de l'enfant illØgitime d'un Øminent membre du parlement."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -10622,11 +10622,11 @@
         Language: fre
         Text: "Clips. Dance, pop-rock, R'n'b, hip-hop, rap : «Top clip» offre une programmation Øclectique."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10654,11 +10654,11 @@
         Language: fre
         Text: "Une sØlection des meilleurs clips hip-hop du moment."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10691,11 +10691,11 @@
         "TDE" : "OpØration tigre blanc"
         Text: "Documentaire amØricain rØalisØ en 2009. "OpØration tigre blanc". Bud et Carrie prØparent, non sans mal, la salle d'opØration dans laquelle Emo, le tigre blanc, doit subir une dØlicate intervention chirurgicale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -10725,11 +10725,11 @@
         "AnnØe" : "2014"
         Text: "Documentaire belge rØalisØ en 2014  (1/6). "Nazinga". Dans le sud du Burkina Faso, le ranch Nazinga fait figure d'exception en Afrique de l'Ouest : les troupeaux d'ØlØphants ne cessent de s'agrandir."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -10768,15 +10768,15 @@
         Language: fre
         Text: ""Les puces de Saint-Ouen". Une incursion dans les coulisses du marchØ aux puces de Saint-Ouen."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -10810,15 +10810,15 @@
         Language: fre
         Text: ""L'autoroute des vacances". Durant les vacances scolaires, les automobilistes pressØs de profiter du soleil et du grand air prennent possession des autoroutes franĿaises."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -10861,15 +10861,15 @@
         Language: fre
         Text: "ost-traumatique consØcutif au drame qu'elle vient de vivre."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -10909,15 +10909,15 @@
         Language: fre
         Text: "oin d'atteindre ses objectifs. Quant Ω Francesco, son attitude dØroute Barbara."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -10955,19 +10955,19 @@
         Language: fre
         Text: "eux lØsØ veut rØcupØrer son argent et enlŁve le pŁre du pilote."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+        Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+        Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
         Component tag: 0x01 (1)
         Language: chi
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -11013,15 +11013,15 @@
         Language: fre
         Text: "CIA est poursuivi par un espion qu'il a lui-mŒme formØ."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+        Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0205 (MPEG-1 Layer 2 audio, surround sound)
+        Content/type: 0xF205 (MPEG-1 Layer 2 audio, surround sound)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -11057,11 +11057,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11089,11 +11089,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11130,11 +11130,11 @@
         Language: fre
         Text: "ues."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -11176,11 +11176,11 @@
         Language: fre
         Text: "ement extrŒmement fragile."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -11225,11 +11225,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11257,11 +11257,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11298,19 +11298,19 @@
         Language: fre
         Text: "ey lui demande de l'aider Ω convaincre une riche veuve de faire une donation Ω l'universitØ."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -11346,19 +11346,19 @@
         Language: fre
         Text: "chizophrŁne, Moretti met tout en oeuvre pour impressionner son nouveau chef."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -11404,19 +11404,19 @@
         Language: fre
         Text: "a planŁte Solaris, y dØcouvre d'Øtranges visiteurs, sortis de ses souvenirs."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -11457,19 +11457,19 @@
         Language: fre
         Text: ". Aussi entreprend-il de partir Ω sa recherche."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -11507,11 +11507,11 @@
         Language: fre
         Text: "Sports extrŒmes."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11559,11 +11559,11 @@
         Language: fre
         Text: "Sports extrŒmes."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11620,11 +11620,11 @@
         Language: fre
         Text: "s eux."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -11670,11 +11670,11 @@
         "AnnØe" : "2015"
         Text: "Documentaire amØricain rØalisØ en 2015 (Ep. 8). "ProblŁmes de peau". DØcouverte de la naissance d'un pingouin et de son apprentissage de la nage ; rencontre ensuite avec un fennec et un chien chanteur de Nouvelle-GuinØe."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -11720,11 +11720,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11753,11 +11753,11 @@
         "AnnØe" : "2013"
         Text: "DIFFUSE EN HD. (-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -11790,11 +11790,11 @@
         "Direct" : "Direct"
         Text: "EN DIRECT.  Universiade d'ØtØ 2017. 4e jour. A Taŉwan."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11833,11 +11833,11 @@
         Language: fre
         Text: "Universiade d'ØtØ 2017. Finale par appareils. A Taŉwan."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11874,11 +11874,11 @@
         Language: fre
         Text: " Qu'est-il arrivØ au Vanuatu pour qu'il soit transformØ Ω ce point ?."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -11920,11 +11920,11 @@
         Language: fre
         Text: "n Australie. Lola confie Ω LØo qu'elle pense avoir trouvØ l'homme qu'il lui faut."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -11966,11 +11966,11 @@
         Language: fre
         Text: "EN DIRECT.  Toutes les courses depuis l'hippodrome de Saint-Malo. "RØunion de Saint-Malo". Hippisme. Mixte."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -11998,11 +11998,11 @@
         Language: fre
         Text: "EN DIRECT.  Toutes les courses depuis l'hippodromede Vincennes (QuintØ+). "RØunion de Vincennes". Hippisme. Trot."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12039,15 +12039,15 @@
         Language: fre
         Text: "mal Ω se faire Ω leur condition de jeunes retraitØs. Quant Ω Manon, elle se dØvergonde."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12082,15 +12082,15 @@
         Language: fre
         Text: "r nouvelle vie, ce qui se rØvŁle plus difficile pour l'un que pour l'autre."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12122,15 +12122,15 @@
         Language: fre
         Text: "Club Europe - Tutta Serie A Football."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -12164,15 +12164,15 @@
         Language: fre
         Text: "Club Europe - Die Bulischau Football."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -12209,11 +12209,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12241,11 +12241,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12276,11 +12276,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12308,11 +12308,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12349,15 +12349,15 @@
         Language: fre
         Text: "s malgrØ lui. Plus tard, Larry rencontre Ricky  Gervais."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12393,15 +12393,15 @@
         "RØalisateur" : "Matthieu Landour"
         Text: "RØalisØ par Matthieu Landour en 2015. Avec Anthony Sonigo, Silvie Laguna, ClØmence Ansault. Court mØtrage franĿais."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -12438,11 +12438,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12470,11 +12470,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12510,15 +12510,15 @@
         Language: fre
         Text: "Ces histoires vraies sont interprØtØes par des comØdiens."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12557,15 +12557,15 @@
         Language: fre
         Text: " vraies sont interprØtØes par des comØdiens, Øcrites et rØalisØes comme un reportage."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -12608,11 +12608,11 @@
         Language: fre
         Text: "croit avoir trouvØ le coupable en la personne d'un enseignant."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -12646,11 +12646,11 @@
         Language: fre
         Text: "rte au silence du corps mØdical, ce qui complique ses  recherches."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -12687,15 +12687,15 @@
         Language: fre
         Text: "Łle et tient Ω faire quelque chose d'original pour sa fŒte."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -12729,19 +12729,19 @@
         Language: fre
         Text: " soient prŒts en mŒme temps pour se rendre Ω un ØvØnement trŁs important."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -12779,19 +12779,19 @@
         Language: fre
         Text: "nØes dans les bois. Sans famille, il prØtend avoir ØtØ ØlevØ par un dragon gØant."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -12827,19 +12827,19 @@
         Language: fre
         Text: "d, Diego, Manny et leurs amis cherchent un moyen de stopper l'apocalypse imminente."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -12873,11 +12873,11 @@
         "Numero de l'Øpisode" : "49"
         Text: "SØrie dramatique avec Funke Akindele, Olayode Juliana, Arike Akinyanju. (49/65). Suliat, une coiffeuse de village, dØbarque en ville pour tenter de rentrer Ω l'universitØ. Sa nouvelle vie en ville ne sera pas de tout repos."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12906,11 +12906,11 @@
         "RØalisateur" : "Femi Olusina"
         Text: "RØalisØ par Femi Olusina. Avec Feyi Adepoju, Rotimi Amodj. Drame."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -12942,11 +12942,11 @@
         "PrØsentateur" : "Jean-Pierre Pernaut"
         Text: "DIFFUSE EN HD.  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 8 bytes
@@ -12976,11 +12976,11 @@
         Language: fre
         Text: "DIFFUSE EN HD.  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 8 bytes
@@ -13013,11 +13013,11 @@
         Language: fre
         Text: "Clips."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13045,11 +13045,11 @@
         Language: fre
         Text: "Clips."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13086,11 +13086,11 @@
         Language: fre
         Text: " roman de Pierre Loti, «Les DØsenchantØes»."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13130,15 +13130,15 @@
         Language: fre
         Text: "ation des camps, filme Ingrid Bergman et Cary Grant dans un thriller d'une rare noirceur."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -13175,11 +13175,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13207,11 +13207,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13242,11 +13242,11 @@
         Language: fre
         Text: "Clips."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13274,11 +13274,11 @@
         Language: fre
         Text: "Clips. M6 Music propose de retrouver une compilation des meilleurs clips du moment."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13309,11 +13309,11 @@
         Language: fre
         Text: "EN DIRECT.  Au sommaire : "Une semaine en..."."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13341,11 +13341,11 @@
         Language: fre
         Text: "EN DIRECT.  Au sommaire : "Une semaine en..."."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13376,11 +13376,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13408,11 +13408,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13449,11 +13449,11 @@
         Language: fre
         Text: "la Normandie : un fait historique crucial dans la libØration du pays."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13501,11 +13501,11 @@
         Language: fre
         Text: "squ'au sacrifice de la personne."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13547,11 +13547,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13579,11 +13579,11 @@
         Language: fre
         Text: "Emission du bien-Œtre. "Eat.Sleep.Surf : Taŉwan 03"."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13620,11 +13620,11 @@
         Language: fre
         Text: "l, sans prØvenir personne."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13658,11 +13658,11 @@
         Language: fre
         Text: "ncontres."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -13693,11 +13693,11 @@
         Language: fre
         Text: "Championnat d'Europe 2017. 6e manche. A Kristianstad (SuŁde)."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13745,11 +13745,11 @@
         Language: fre
         Text: ""Episode 6". Automobiles, motos ou machines Øtonnantes sont montØes et essayØes par les meilleurs prØparateurs de la  planŁte."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13791,11 +13791,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13823,11 +13823,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13858,11 +13858,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13890,11 +13890,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -13931,15 +13931,15 @@
         Language: fre
         Text: "nt des histoires incroyables : conflits de quartier, amours interdites, mensonges, secrets ou jalousies."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -13983,11 +13983,11 @@
         Language: fre
         Text: "Une personnalitØ invite Ω dØcouvrir l'endroit oø elle rŒverait d'emmener un Œtre cher."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14024,15 +14024,15 @@
         Language: fre
         Text: "n poste situØ au plus bas de l'Øchelle."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -14067,15 +14067,15 @@
         Language: fre
         Text: " ce qui dØplaŊt fortement Ω Michael, qui lui fait connaŊtre son avis sur la question."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -14113,15 +14113,15 @@
         Language: fre
         Text: " elle se retrouve sur les bords d'une riviŁre."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -14162,15 +14162,15 @@
         Language: fre
         Text: "trouve sur les bords d'une riviŁre, prŁs d'une forŒt et d'une petite ville."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+        Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -14208,11 +14208,11 @@
         Language: fre
         Text: "The Late Late Show with James Corden Talk show. "Episode 86". James Corden reĿoit sur son plateau les personnalitØs qui font l'actualitØ amØricaine et internationale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14248,11 +14248,11 @@
         Language: fre
         Text: "Clips. Un espace musical exclusivement rØservØ aux clips. MCM propose une sØlection des tubes du moment. C'est l'occasion de dØcouvrir les derniŁres nouveautØ de la variØtØ mondiale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14289,19 +14289,19 @@
         Language: fre
         Text: "sformer leur oncle en parfait candidat."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -14336,15 +14336,15 @@
         Language: fre
         Text: " et de surmonter leurs diffØrentes peurs."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -14386,15 +14386,15 @@
         Language: fre
         Text: "riage assis devant la tØlØ, Frankie met les ZhuZhus Ω contribution pour organiser une soirØe."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -14439,15 +14439,15 @@
         Language: fre
         Text: "bien failli les asperger de son liquide malodorant."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Content (0x54, 84), 4 bytes
@@ -14489,11 +14489,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14521,11 +14521,11 @@
         Language: fre
         Text: "beIN SPORTS, le plus grand des spectacles."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14556,11 +14556,11 @@
         Language: fre
         Text: "(-18)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14588,11 +14588,11 @@
         Language: fre
         Text: "(-16)  Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14624,15 +14624,15 @@
         "PrØsentateur" : "Michel Cymes"
         Text: "Les docs du Mag de la santØ PrØsentØ par Michel Cymes, Marina CarrŁre d'Encausse. Au sommaire : "Etre mŁre au-delΩ du cancer". - "Le rallye des Gazelles"."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 6 bytes
@@ -14667,15 +14667,15 @@
         Language: fre
         Text: "dans l'horizon, et pour les Mormons."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -14707,11 +14707,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14741,11 +14741,11 @@
         "RØalisateur" : "StØphane Berry"
         Text: "(-18)  TXTCOURT."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14776,11 +14776,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14808,11 +14808,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14849,19 +14849,19 @@
         Language: fre
         Text: "t Beckett les conduit Ω s'intØresser Ω la mafia irlandaise de Staten Island."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -14896,19 +14896,19 @@
         Language: fre
         Text: "es jumelles pour tromper l'ennui, est tØmoin d'un meurtre."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+        Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+        Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 7: Content (0x54, 84), 6 bytes
@@ -14942,11 +14942,11 @@
         "TDE" : "Le rival"
         Text: "SØrie jeunesse amØricaine avec Keke Palmer, Ashley Argota, Matt Shively. Saison 1. (10/26). "Le rival". Le concurrent et ennemi jurØ de Max fait les yeux doux Ω True pour qu'elle accepte de travailler pour lui."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -14980,11 +14980,11 @@
         Language: fre
         Text: "primer ses sentiments, elle se rØfugie dans la musique."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -15015,11 +15015,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -15047,11 +15047,11 @@
         Language: fre
         Text: "Information non disponible."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 4 bytes

--- a/reference/test-002/test-002.tstabdump.txt
+++ b/reference/test-002/test-002.tstabdump.txt
@@ -967,11 +967,11 @@
       Language: ita
       Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1002,11 +1002,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1428,11 +1428,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1456,11 +1456,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1504,11 +1504,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1539,11 +1539,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1574,11 +1574,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1609,11 +1609,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2094,11 +2094,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2129,11 +2129,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2168,11 +2168,11 @@
       Language: ita
       Text: "reschi. Chi trovera' la casa perfetta?"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2203,11 +2203,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2244,11 +2244,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2313,11 +2313,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2662,11 +2662,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2697,11 +2697,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3265,11 +3265,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3304,11 +3304,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3609,11 +3609,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3678,11 +3678,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4209,11 +4209,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4285,11 +4285,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4356,11 +4356,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4391,11 +4391,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4443,11 +4443,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4478,11 +4478,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4661,11 +4661,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4696,11 +4696,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4737,11 +4737,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4782,11 +4782,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4827,11 +4827,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4896,11 +4896,11 @@
       Language: ita
       Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4937,11 +4937,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5006,11 +5006,11 @@
       Language: ita
       Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5545,11 +5545,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5586,11 +5586,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes

--- a/reference/test-002/test-002.tstables.text.txt
+++ b/reference/test-002/test-002.tstables.text.txt
@@ -1024,11 +1024,11 @@
         Language: ita
         Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1057,11 +1057,11 @@
         Language: ita
         Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1485,11 +1485,11 @@
         Reference service id: 0x0BB8 (3000)
         Reference event id: 0x9AB0 (39600)
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1511,11 +1511,11 @@
         Reference service id: 0x0BB8 (3000)
         Reference event id: 0x3000 (12288)
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1560,11 +1560,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1593,11 +1593,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1629,11 +1629,11 @@
         Language: ita
         Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1662,11 +1662,11 @@
         Language: ita
         Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2149,11 +2149,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2182,11 +2182,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2222,11 +2222,11 @@
         Language: ita
         Text: "reschi. Chi trovera' la casa perfetta?"
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2255,11 +2255,11 @@
         Language: ita
         Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2297,11 +2297,11 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: ITA, rating: 0x09 (min. 12 years)
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2364,11 +2364,11 @@
         Language: ita
         Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2714,11 +2714,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2747,11 +2747,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3313,11 +3313,11 @@
         Language: ita
         Text: "."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3350,11 +3350,11 @@
         Language: ita
         Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3669,11 +3669,11 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: ITA, rating: 0x0B (min. 14 years)
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3736,11 +3736,11 @@
         Language: ita
         Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4313,11 +4313,11 @@
       - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
         Country code: ITA, rating: 0x0B (min. 14 years)
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4387,11 +4387,11 @@
       - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
         Country code: ITA, rating: 0x0B (min. 14 years)
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4459,11 +4459,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4492,11 +4492,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4546,11 +4546,11 @@
         Language: ita
         Text: "test"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4579,11 +4579,11 @@
         Language: ita
         Text: "test"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4764,11 +4764,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4797,11 +4797,11 @@
         Language: ita
         Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4903,11 +4903,11 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: ITA, rating: 0x0B (min. 14 years)
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4946,11 +4946,11 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: ITA, rating: 0x0B (min. 14 years)
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4992,11 +4992,11 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: ITA, rating: 0x09 (min. 12 years)
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5059,11 +5059,11 @@
         Language: ita
         Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5101,11 +5101,11 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: ITA, rating: 0x09 (min. 12 years)
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5168,11 +5168,11 @@
         Language: ita
         Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5713,11 +5713,11 @@
         Language: ita
         Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5752,11 +5752,11 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: ITA, rating: 0x09 (min. 12 years)
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0xFF (255)
         Language:    
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0xFF (255)
         Language: ita
       - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes

--- a/reference/test-015/test-015.tstabdump.txt
+++ b/reference/test-015/test-015.tstabdump.txt
@@ -4,7 +4,7 @@
   Program: 0x0000 (0), PCR PID: none
   Program information:
   - Descriptor 0: Component (0x50, 80), 6 bytes
-    Content/type: 0x0102 (MPEG-2 video, 16:9 aspect ratio with pan vectors, 25 Hz)
+    Content/type: 0xF102 (MPEG-2 video, 16:9 aspect ratio with pan vectors, 25 Hz)
     Component tag: 0x00 (0)
     Language: fre
   - Descriptor 1: Component (0x50, 80), 26 bytes

--- a/reference/test-015/test-015.tstables.txt
+++ b/reference/test-015/test-015.tstables.txt
@@ -5,7 +5,7 @@
     Program: 0x0000 (0), PCR PID: none
     Program information:
     - Descriptor 0: Component (0x50, 80), 6 bytes
-      Content/type: 0x0102 (MPEG-2 video, 16:9 aspect ratio with pan vectors, 25 Hz)
+      Content/type: 0xF102 (MPEG-2 video, 16:9 aspect ratio with pan vectors, 25 Hz)
       Component tag: 0x00 (0)
       Language: fre
     - Descriptor 1: Component (0x50, 80), 26 bytes

--- a/reference/test-030/test-030.tables.txt
+++ b/reference/test-030/test-030.tables.txt
@@ -83,11 +83,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -122,11 +122,11 @@
       Language: ita
       Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -158,11 +158,11 @@
       "PrØsentateur" : "Julien Desvages"
       Text: "EN DIRECT.  TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -192,11 +192,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Gant d'Or 2017. Finale. A Biarritz (PyrØnØes-Atlantiques)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -233,19 +233,19 @@
       Language: fre
       Text: "n chien. Il s'en dØbarrasse rapidement. Pris de remords, il dØcide de l'aider."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -292,11 +292,11 @@
       Language: ita
       Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -384,11 +384,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -414,11 +414,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -453,19 +453,19 @@
       Language: fre
       Text: "nØes dans les bois. Sans famille, il prØtend avoir ØtØ ØlevØ par un dragon gØant."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -503,11 +503,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -615,15 +615,15 @@
       Language: fre
       Text: "ir afin de pouvoir combattre un cruel ennemi qui menace le monde des humains."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -679,11 +679,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -709,11 +709,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -757,11 +757,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -792,11 +792,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -827,11 +827,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -862,11 +862,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -901,11 +901,11 @@
       Language: ita
       Text: "reschi. Chi trovera' la casa perfetta?"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -997,15 +997,15 @@
       Language: fre
       Text: "obile."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -1043,19 +1043,19 @@
       Language: fre
       Text: "tour au commissariat. Amy s'interroge sur les longues pauses effectuØes par Rosa."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -1100,11 +1100,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1165,11 +1165,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1200,11 +1200,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1296,11 +1296,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1331,11 +1331,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1372,15 +1372,15 @@
       Language: fre
       Text: "s connu. Il se rend Ω MontrØal afin d'en savoir plus sur lui."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -1420,11 +1420,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1465,19 +1465,19 @@
       Language: fre
       Text: "d'arrŒter un soldat sudiste qui a massacrØ sa famille."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -1580,11 +1580,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1645,11 +1645,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1680,11 +1680,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1725,19 +1725,19 @@
       Language: fre
       Text: "idieusement dans l'intimitØ d'une vedette de thØĐtre sur le dØclin."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -1778,11 +1778,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1872,11 +1872,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1981,11 +1981,11 @@
       "PrØsentateur" : "Julien Desvages"
       Text: "EN DIRECT.  TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -2015,11 +2015,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2050,11 +2050,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Lorient (L2) / Lens (L2) Coupe de la Ligue. 2e tour."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -2090,15 +2090,15 @@
       Language: fre
       Text: "DIFFUSE EN HD.  "EtØ 2011". Avec l'humour et la tchatche qui le caractØrisent, Kamel, intervenant rØgulier du «Grand Journal», propose des tours de magie rØalisØs dans des lieux insolites."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -2194,11 +2194,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2265,11 +2265,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2300,11 +2300,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2335,11 +2335,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2370,11 +2370,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2468,19 +2468,19 @@
       Language: fre
       Text: "d, Diego, Manny et leurs amis cherchent un moyen de stopper l'apocalypse imminente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -2518,11 +2518,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2589,15 +2589,15 @@
       Language: fre
       Text: "it Prince."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -2637,11 +2637,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2678,11 +2678,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2721,11 +2721,11 @@
       Language: ita
       Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2819,15 +2819,15 @@
       Language: fre
       Text: "le but de percer le secret de la subtile «nihon ryħri», la cuisine nippone."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -2870,19 +2870,19 @@
       Language: fre
       Text: "ets au sein du commissariat. Chacun se dØmŁne pour avoir le trophØe en jeu."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -2927,11 +2927,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2998,11 +2998,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3094,11 +3094,11 @@
       Language: ita
       Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3133,11 +3133,11 @@
       Language: ita
       Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3172,11 +3172,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3213,15 +3213,15 @@
       Language: fre
       Text: "rise de remords, la praticienne dØcide d'enquŒter sur l'inconnue."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -3278,19 +3278,19 @@
       Language: fre
       Text: "pour fournir au FBI les preuves nØcessaires Ω un Øventuel procŁs."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -3327,11 +3327,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3373,11 +3373,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3453,11 +3453,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3518,11 +3518,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3548,11 +3548,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3602,19 +3602,19 @@
       Language: fre
       Text: "contre une jeune hØritiŁre extravagante et son gentil lØopard."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -3657,11 +3657,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3749,11 +3749,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3784,11 +3784,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3819,11 +3819,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3855,11 +3855,11 @@
       "PrØsentateur" : "Julien Desvages"
       Text: "EN DIRECT.  TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -3946,11 +3946,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Gant d'Or 2017. Finale. A Biarritz (PyrØnØes-Atlantiques)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -3987,19 +3987,19 @@
       Language: fre
       Text: "n chien. Il s'en dØbarrasse rapidement. Pris de remords, il dØcide de l'aider."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -4048,11 +4048,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4113,11 +4113,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4148,11 +4148,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4187,11 +4187,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4222,11 +4222,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4320,19 +4320,19 @@
       Language: fre
       Text: "nØes dans les bois. Sans famille, il prØtend avoir ØtØ ØlevØ par un dragon gØant."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -4368,11 +4368,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4413,15 +4413,15 @@
       Language: fre
       Text: "ir afin de pouvoir combattre un cruel ennemi qui menace le monde des humains."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -4467,11 +4467,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4532,11 +4532,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4624,11 +4624,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4667,15 +4667,15 @@
       Language: fre
       Text: "obile."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -4713,19 +4713,19 @@
       Language: fre
       Text: "tour au commissariat. Amy s'interroge sur les longues pauses effectuØes par Rosa."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -4768,11 +4768,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4862,11 +4862,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4942,15 +4942,15 @@
       Language: fre
       Text: "s connu. Il se rend Ω MontrØal afin d'en savoir plus sur lui."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -4986,11 +4986,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5027,19 +5027,19 @@
       Language: fre
       Text: "d'arrŒter un soldat sudiste qui a massacrØ sa famille."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -5081,11 +5081,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5152,11 +5152,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5244,11 +5244,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5279,11 +5279,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5314,11 +5314,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5355,19 +5355,19 @@
       Language: fre
       Text: "idieusement dans l'intimitØ d'une vedette de thØĐtre sur le dØclin."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -5404,11 +5404,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5502,11 +5502,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5545,11 +5545,11 @@
       Language: ita
       Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5581,11 +5581,11 @@
       "PrØsentateur" : "Julien Desvages"
       Text: "EN DIRECT.  TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -5615,11 +5615,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Lorient (L2) / Lens (L2) Coupe de la Ligue. 2e tour."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -5655,15 +5655,15 @@
       Language: fre
       Text: "DIFFUSE EN HD.  "EtØ 2011". Avec l'humour et la tchatche qui le caractØrisent, Kamel, intervenant rØgulier du «Grand Journal», propose des tours de magie rØalisØs dans des lieux insolites."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -5820,19 +5820,19 @@
       Language: fre
       Text: "d, Diego, Manny et leurs amis cherchent un moyen de stopper l'apocalypse imminente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -5870,15 +5870,15 @@
       Language: fre
       Text: "it Prince."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -5922,11 +5922,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5957,11 +5957,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5987,11 +5987,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6083,11 +6083,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6148,11 +6148,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6189,15 +6189,15 @@
       Language: fre
       Text: "le but de percer le secret de la subtile «nihon ryħri», la cuisine nippone."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -6229,11 +6229,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6283,19 +6283,19 @@
       Language: fre
       Text: "ets au sein du commissariat. Chacun se dØmŁne pour avoir le trophØe en jeu."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -6334,11 +6334,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6369,11 +6369,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6404,11 +6404,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6455,11 +6455,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6535,11 +6535,11 @@
       Language: ita
       Text: "reschi. Chi trovera' la casa perfetta?"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6576,15 +6576,15 @@
       Language: fre
       Text: "rise de remords, la praticienne dØcide d'enquŒter sur l'inconnue."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -6641,19 +6641,19 @@
       Language: fre
       Text: "pour fournir au FBI les preuves nØcessaires Ω un Øventuel procŁs."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -6690,11 +6690,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6782,11 +6782,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6821,11 +6821,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6856,11 +6856,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6895,11 +6895,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -6940,19 +6940,19 @@
       Language: fre
       Text: "contre une jeune hØritiŁre extravagante et son gentil lØopard."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -7058,11 +7058,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7123,11 +7123,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7158,11 +7158,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7255,11 +7255,11 @@
       "PrØsentateur" : "Julien Desvages"
       Text: "EN DIRECT.  TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -7293,11 +7293,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7328,11 +7328,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Gant d'Or 2017. Finale. A Biarritz (PyrØnØes-Atlantiques)."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -7369,19 +7369,19 @@
       Language: fre
       Text: "n chien. Il s'en dØbarrasse rapidement. Pris de remords, il dØcide de l'aider."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -7458,11 +7458,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7556,19 +7556,19 @@
       Language: fre
       Text: "nØes dans les bois. Sans famille, il prØtend avoir ØtØ ØlevØ par un dragon gØant."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -7606,15 +7606,15 @@
       Language: fre
       Text: "ir afin de pouvoir combattre un cruel ennemi qui menace le monde des humains."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -7656,11 +7656,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7727,11 +7727,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7762,11 +7762,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7797,11 +7797,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7832,11 +7832,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7930,11 +7930,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -7995,11 +7995,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8034,15 +8034,15 @@
       Language: fre
       Text: "obile."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -8080,19 +8080,19 @@
       Language: fre
       Text: "tour au commissariat. Amy s'interroge sur les longues pauses effectuØes par Rosa."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -8137,11 +8137,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8180,11 +8180,11 @@
       Language: ita
       Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8278,11 +8278,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8349,15 +8349,15 @@
       Language: fre
       Text: "s connu. Il se rend Ω MontrØal afin d'en savoir plus sur lui."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
+      Content/type: 0xF321 (DVB subtitles for hard of hearing, 4:3 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 6 bytes
@@ -8456,11 +8456,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8501,19 +8501,19 @@
       Language: fre
       Text: "d'arrŒter un soldat sudiste qui a massacrØ sa famille."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -8553,11 +8553,11 @@
       Language: ita
       Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8592,11 +8592,11 @@
       Language: ita
       Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8631,11 +8631,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8713,19 +8713,19 @@
       Language: fre
       Text: "idieusement dans l'intimitØ d'une vedette de thØĐtre sur le dØclin."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -8778,11 +8778,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8808,11 +8808,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8847,11 +8847,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8912,11 +8912,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -8948,11 +8948,11 @@
       "PrØsentateur" : "Julien Desvages"
       Text: "EN DIRECT.  TXT0."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0201 (MPEG-1 Layer 2 audio, single mono channel)
+      Content/type: 0xF201 (MPEG-1 Layer 2 audio, single mono channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 4 bytes
@@ -9039,11 +9039,11 @@
       Language: fre
       Text: "DIFFUSE EN HD.  Lorient (L2) / Lens (L2) Coupe de la Ligue. 2e tour."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -9074,11 +9074,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9122,15 +9122,15 @@
       Language: fre
       Text: "DIFFUSE EN HD.  "EtØ 2011". Avec l'humour et la tchatche qui le caractØrisent, Kamel, intervenant rØgulier du «Grand Journal», propose des tours de magie rØalisØs dans des lieux insolites."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Content (0x54, 84), 8 bytes
@@ -9167,11 +9167,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9202,11 +9202,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9237,11 +9237,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9335,19 +9335,19 @@
       Language: fre
       Text: "d, Diego, Manny et leurs amis cherchent un moyen de stopper l'apocalypse imminente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 8 bytes
@@ -9385,15 +9385,15 @@
       Language: fre
       Text: "it Prince."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -9439,11 +9439,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9504,11 +9504,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9539,11 +9539,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9637,15 +9637,15 @@
       Language: fre
       Text: "le but de percer le secret de la subtile «nihon ryħri», la cuisine nippone."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Content (0x54, 84), 8 bytes
@@ -9686,11 +9686,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9721,11 +9721,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9762,19 +9762,19 @@
       Language: fre
       Text: "ets au sein du commissariat. Chacun se dØmŁne pour avoir le trophØe en jeu."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 7: Content (0x54, 84), 10 bytes
@@ -9817,11 +9817,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9903,11 +9903,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -9984,11 +9984,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes

--- a/reference/test-038/test-038.tstabdump.txt
+++ b/reference/test-038/test-038.tstabdump.txt
@@ -39,23 +39,23 @@ Velká zábavná show, ve které nic není nemožné. Svou pohotovost tentokrát
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:00 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -82,15 +82,15 @@ Velká zábavná show, ve které nic není nemožné. Svou pohotovost tentokrát
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -156,19 +156,19 @@ Mezinárodně oceněný výpravný seriál tvůrců Toma Tykwera (Lola běží o
     - Descriptor 9: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:50 (MM-DD hh:mm)
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 13: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -196,19 +196,19 @@ Mezinárodně oceněný výpravný seriál tvůrců Toma Tykwera (Lola běží o
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -234,19 +234,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -271,15 +271,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -305,19 +305,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -356,15 +356,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -391,15 +391,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -438,15 +438,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:25 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -475,15 +475,15 @@ Skryté titulky"
 2 jazykové verze
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -510,15 +510,15 @@ Skryté titulky"
 2 jazykové verze
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -542,11 +542,11 @@ Skryté titulky"
       "Žánr" : "animovaný / loutkový"
       Text: "16:9"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -571,15 +571,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -604,15 +604,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -638,15 +638,15 @@ Skryté titulky"
 2 jazykové verze
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -687,19 +687,19 @@ Hugo Mazal objeví bohatého podnikatele jménem Hilbert von Koblischek a přim�
       Language: cze
       Text: "ádkové kontrolní komise, on sám má zájem spíše o ženy než o gotické hrady a situaci rozhodně nezachrání, když Hugo omylem vypije sérum pravdy a Hilbertovi prozradí, jak to s hradem a jeho strašidly opravdu je..."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -724,15 +724,15 @@ Hugo Mazal objeví bohatého podnikatele jménem Hilbert von Koblischek a přim�
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -756,11 +756,11 @@ Skryté titulky"
       "Žánr" : "vzdělávací pořad pro děti"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -785,11 +785,11 @@ Skryté titulky"
       "Žánr" : "animovaný / loutkový"
       Text: "4:3"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -814,15 +814,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -885,15 +885,15 @@ Na předávání křišťálových trofejí s grafikou jedné z Janáčko"
     - Descriptor 9: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:20 (MM-DD hh:mm)
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -1622,19 +1622,19 @@ Na předávání křišťálových trofejí s grafikou jedné z Janáčko"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -1661,19 +1661,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -1697,11 +1697,11 @@ Skryté titulky"
       "Žánr" : "kviz / soutěž"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -1747,19 +1747,19 @@ Komisař Vašátko (V. Preiss) se na dovolené na horské chatě potká s malí�
       Language: cze
       Text: "olicie se kvůli vichřici nemůže do chaty dostat, a tak se vyšetřování ujímá přítomný a zkušený komisař Vašátko. Chata je plná lidí, kteří mají silné motivy k vraždě..."
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -1785,15 +1785,15 @@ Komisař Vašátko (V. Preiss) se na dovolené na horské chatě potká s malí�
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -1829,19 +1829,19 @@ Nová talkshow Vaška Kopty představí známé tváře úplně jinak, než jsme
       Language: cze
       Text: "edničce. Byla někdy biatlonistka ve výslužbě Gábina Koukalová na rybách? Kam nejdál dojel režisér Honza Hřebejk na běžkách? A nosí nejslavnější český rybář Jakub Vágner někdy pruhované triko? Uvidíte!"
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -1915,19 +1915,19 @@ V noci, kdy umírá hoteliér Eduard Sacher, dojde také k únosu jedenáctilet�
     - Descriptor 11: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:15 (MM-DD hh:mm)
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 13: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 14: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 15: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -1954,15 +1954,15 @@ V noci, kdy umírá hoteliér Eduard Sacher, dojde také k únosu jedenáctilet�
       Text: "HDTV
 Znakový jazyk"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+      Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -2015,15 +2015,15 @@ Western Strom na věšení (1959) vznikl podle stejnojmenné novely Dorothy M. J
       Language: cze
       Text: "í onemocněl, takže za něho musel anonymně zaskočit právě Karl Malden. Snímek se odehrává v Montaně, ale natáčel se v horské krajině poblíž města Yakima ve státě Washington. Titulní písnička byla nominována na Oscara."
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Content (0x54, 84), 2 bytes
@@ -2070,15 +2070,15 @@ Ačkoli dobové ohlasy filmu kultovního režiséra Johna Carpentera vytýkaly, 
       Language: cze
       Text: " houstnoucí napětí i krvavé surové scény ukazující, jak invazivní organismus se svými hostiteli nakládá."
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -2147,19 +2147,19 @@ Skryté titulky
     - Descriptor 11: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:40 (MM-DD hh:mm)
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 13: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 14: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 15: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -2187,19 +2187,19 @@ Skryté titulky
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -2223,11 +2223,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -2254,19 +2254,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -2291,15 +2291,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -2324,15 +2324,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -2358,19 +2358,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -2394,11 +2394,11 @@ Skryté titulky"
       "Žánr" : "zpravodajský magazín"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -2438,19 +2438,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -2477,15 +2477,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -2510,15 +2510,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -2557,15 +2557,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -2592,15 +2592,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -2626,15 +2626,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -2659,11 +2659,11 @@ Skryté titulky"
       "Žánr" : "animovaný / loutkový"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -2690,19 +2690,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -2736,15 +2736,15 @@ Skryté titulky
       Language: cze
       Text: "itron, která v posledních ročnících získává na popularitě. O hudební doprovod se postará Vladimír Merta a Jitka Šuranská. Slavnostním večerem nás provede Martin Myšička."
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -2789,15 +2789,15 @@ Pro hlavní roli si Otakar Vávra vybral výborného Karla H"
       Language: cze
       Text: "a mezinárodních filmových festivalech. Nejvyššího uznání se mu dostalo v San Sebastiánu, kde získal v roce 1965 kromě Velké ceny Zlaté mušle ještě dvě další ocenění - Cenu FIPRESCI a Cenu CIDALC."
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -2864,15 +2864,15 @@ Povolání: reportér patří k divácky nejvstřícnějším dílům z Antonion
     - Descriptor 10: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:40 (MM-DD hh:mm)
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 13: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -3649,11 +3649,11 @@ Povolání: reportér patří k divácky nejvstřícnějším dílům z Antonion
       "Žánr" : "kviz / soutěž"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -3697,15 +3697,15 @@ S kapitánem Exnerem, pověstným el"
       Language: cze
       Text: "íra Kratinu a Karla Augustu."
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -3743,15 +3743,15 @@ Zemře-li násilnou smrtí mladá, půvabná žena, u níž nelze ex post vylou�
       Language: cze
       Text: " horákyni - jaksi konalo i nekonalo..."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -3800,15 +3800,15 @@ Staneme se svědky setká"
       Language: cze
       Text: "církví po desetiletí praktikovaná metoda, jak provinilce úspěšně dostat do bezpečí?"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -3854,15 +3854,15 @@ Tento díl je věnován období, kdy se rasistické zákony o říšském státn
       Language: cze
       Text: "žení proti Sovětskému svazu se protahuje a pohotovostní oddíly vraždí i ženy a děti."
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -3895,15 +3895,15 @@ Tento díl je věnován období, kdy se rasistické zákony o říšském státn
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -3933,15 +3933,15 @@ Skryté titulky"
 HDTV
 Skryté titulky"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -3967,15 +3967,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -3999,11 +3999,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -4029,15 +4029,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -4064,19 +4064,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -4100,11 +4100,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -4145,15 +4145,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
 -zákon o liniových stavbách
 -délka stavebního řízení"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -4186,15 +4186,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -4220,15 +4220,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -4254,15 +4254,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -4288,15 +4288,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -4338,11 +4338,11 @@ Svátek pro milovníky špičkových bigbandů připravil festival Prague Proms 
       Language: cze
       Text: " Grammy, včetně té za hudební aranže písně The Incredits z filmu Úžasňákovi. Je také držitelem tří cen Emmy."
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -4400,15 +4400,15 @@ Divadelní fond českokrumlovské zámecké scény zahrnuje kromě vlastní budo
       Language: cze
       Text: "rálovském paláci v Drottningholmu."
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 12: Content (0x54, 84), 2 bytes
@@ -5177,15 +5177,15 @@ Divadelní fond českokrumlovské zámecké scény zahrnuje kromě vlastní budo
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -5450,19 +5450,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -5867,19 +5867,19 @@ Dnešní díl je poněkud atypický. Vracíme se k některým zajímavým příb
       Language: cze
       Text: " je upřímně překvapen. Právě na těchto příbězích je vidět obrovské úsilí a maximální snahu všech zúčastněných o vyladění vzájemného soužití."
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 12: Content (0x54, 84), 2 bytes
@@ -5918,15 +5918,15 @@ Začátkem roku odlehčíme našim peněženkám, což ovšem neznamená, že se
       Language: cze
       Text: "obalované v ořechách a rozinkách marinovaných v rumu."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -5958,19 +5958,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 18:55 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -6015,15 +6015,15 @@ Až z druhého konce planety jezdí do Botswany lidé, aby obdivovali tamní př
       Text: "baby. 
 Botswana si zaslouží stále více pozornosti. Den po dni se obrací zády k historii chudé země bez jakékoli perspektivy."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -6047,11 +6047,11 @@ Botswana si zaslouží stále více pozornosti. Den po dni se obrací zády k hi
       "Žánr" : "animovaný / loutkový"
       Text: "4:3"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -6077,19 +6077,19 @@ Botswana si zaslouží stále více pozornosti. Den po dni se obrací zády k hi
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -6123,19 +6123,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -6176,15 +6176,15 @@ Byl přítelem Jana Palacha v době studií v Praze. I na základě jeho činu p
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 18:27 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4AFE (19198)
@@ -6210,19 +6210,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 18:55 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -6250,15 +6250,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -6284,15 +6284,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -6336,15 +6336,15 @@ Deset úžasných dětských kuchařů čeká další dobrodružství v kuchyni 
       Language: cze
       Text: "dání: připravit jídlo, které proslavil sám Gordon Ramsay - proslulou hovězí svíčkovou Wellington. Dvojice kulinářských adeptů si sáhnou na dno svých sil, ale ani to nezachrání před odchodem ze soutěže další dva z nich."
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -6370,15 +6370,15 @@ Deset úžasných dětských kuchařů čeká další dobrodružství v kuchyni 
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -6402,11 +6402,11 @@ Skryté titulky"
       "Žánr" : "vzdělávací pořad pro děti"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -6430,11 +6430,11 @@ Skryté titulky"
       "Žánr" : "animovaný / loutkový"
       Text: "4:3"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -6459,15 +6459,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -6584,19 +6584,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -6623,19 +6623,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -6677,23 +6677,23 @@ Velká zábavná show, ve které nic není nemožné. Svou pohotovost tentokrát
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:00 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B60 (19296)
@@ -6753,19 +6753,19 @@ V noci, kdy umírá hoteliér Eduard Sacher, dojde také k únosu jedenáctilet�
     - Descriptor 11: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:15 (MM-DD hh:mm)
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 13: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 14: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 15: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -6819,15 +6819,15 @@ Mikulovský židovský hřbitov, významný nejen pro svou umělecko-historickou
       Language: cze
       Text: " zasvěceným průvodcem po dané lokalitě místní odborník, který je zapojen do správy a péče o židovské památky. V Mikulově jím bude malířka a galeristka Sylva Chludilová."
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Content (0x54, 84), 2 bytes
@@ -6852,15 +6852,15 @@ Mikulovský židovský hřbitov, významný nejen pro svou umělecko-historickou
       Text: "HDTV
 Znakový jazyk"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+      Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -6894,19 +6894,19 @@ Znakový jazyk"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -6933,19 +6933,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -6970,15 +6970,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -7009,15 +7009,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B55 (19285)
@@ -7043,19 +7043,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B58 (19288)
@@ -7095,19 +7095,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -7134,15 +7134,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -7173,15 +7173,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:25 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -7208,15 +7208,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -7242,15 +7242,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -7274,11 +7274,11 @@ Skryté titulky"
       "Žánr" : "animovaný / loutkový"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -7305,19 +7305,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -7372,15 +7372,15 @@ Na předávání křišťálových trofejí s grafikou jedné z Janáčko"
     - Descriptor 9: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:20 (MM-DD hh:mm)
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -7991,15 +7991,15 @@ Výpravný šestnáctidílný seriál se strhující atmosférou vychází z det
       Language: cze
       Text: "s a v roli zasloužilého policisty Bruna Woltera renomovaného německého herce Petera Kurtha, kterého čeští diváci mohou znát na příklad z titulní role ve snímku Schmitke."
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Content (0x54, 84), 2 bytes
@@ -8057,19 +8057,19 @@ Mezinárodně oceněný výpravný seriál tvůrců Toma Tykwera (Lola běží o
     - Descriptor 9: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:50 (MM-DD hh:mm)
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 13: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -8132,19 +8132,19 @@ Skryté titulky
     - Descriptor 11: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:40 (MM-DD hh:mm)
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 13: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 14: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 15: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -8176,15 +8176,15 @@ Skryté titulky
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:54 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BA6 (19366)
@@ -8222,19 +8222,19 @@ Manažer velké nadnárodní společnosti Wallace Avery (C. Firth) je ve všech 
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:55 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BE6 (19430)
@@ -8259,19 +8259,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:25 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BF9 (19449)
@@ -8296,19 +8296,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:50 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -8372,19 +8372,19 @@ Píše se rok 1941. Britové prohráli leteckou bitvu o Bri"
     - Descriptor 11: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:35 (MM-DD hh:mm)
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 13: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 14: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 15: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -8417,15 +8417,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B84 (19332)
@@ -8461,19 +8461,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:05 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B96 (19350)
@@ -8507,19 +8507,19 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:32 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BAA (19370)
@@ -8543,15 +8543,15 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BBD (19389)
@@ -8576,19 +8576,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:27 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BC8 (19400)
@@ -8615,19 +8615,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:40 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BD5 (19413)
@@ -8651,15 +8651,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BDE (19422)
@@ -8684,15 +8684,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:10 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -8725,15 +8725,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B91 (19345)
@@ -8759,15 +8759,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:25 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BB6 (19382)
@@ -8793,19 +8793,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:15 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BF6 (19446)
@@ -8831,15 +8831,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:45 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C00 (19456)
@@ -8865,19 +8865,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -8938,15 +8938,15 @@ Povolání: reportér patří k divácky nejvstřícnějším dílům z Antonion
     - Descriptor 10: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:40 (MM-DD hh:mm)
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 13: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BCA (19402)
@@ -8980,15 +8980,15 @@ Záznam vystoupení The Killers v Royal Albert Hall vznikl během natáčení dv
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:45 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -9553,15 +9553,15 @@ Záznam vystoupení The Killers v Royal Albert Hall vznikl během natáčení dv
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 20:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -9595,19 +9595,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -9640,19 +9640,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:15 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C1B (19483)
@@ -9677,19 +9677,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:35 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C2B (19499)
@@ -9714,19 +9714,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C3C (19516)
@@ -9751,19 +9751,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:25 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C7D (19581)
@@ -9788,19 +9788,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:55 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -9848,23 +9848,23 @@ V dalším díle dokumentárního cyklu se seznámíme s vápenci a kalcitovými
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:05 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C19 (19481)
@@ -9906,19 +9906,19 @@ Královské dvory a rezidence v jagellonské Evropě 1386-1572 ukazují historii
     - Descriptor 8: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:35 (MM-DD hh:mm)
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C2E (19502)
@@ -9943,19 +9943,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C40 (19520)
@@ -9980,19 +9980,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:30 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C4A (19530)
@@ -10017,19 +10017,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:45 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C5D (19549)
@@ -10055,23 +10055,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:10 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C6A (19562)
@@ -10097,23 +10097,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:30 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -10146,19 +10146,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C1E (19486)
@@ -10185,19 +10185,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:43 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C30 (19504)
@@ -10223,19 +10223,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:09 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C42 (19522)
@@ -10262,19 +10262,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:35 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C67 (19559)
@@ -10301,19 +10301,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:27 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -10348,19 +10348,19 @@ Zvukový popis"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:40 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C54 (19540)
@@ -10386,15 +10386,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -10435,15 +10435,15 @@ Běžnou ranní rutinu, zahrnující Jezovy svérázné projevy osobní svobody 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:40 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C06 (19462)
@@ -10482,19 +10482,19 @@ Frontman AC/DC Brian Johnson navštěvuje dům zpěváka The Who Rogera Daltreyh
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:10 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C26 (19494)
@@ -10529,19 +10529,19 @@ Autor triptychu "Ruské umění" Andrew Graham Dixon připomíná, že bývalá 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:55 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C4B (19531)
@@ -10565,15 +10565,15 @@ Autor triptychu "Ruské umění" Andrew Graham Dixon připomíná, že bývalá 
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:45 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C54 (19540)
@@ -10598,19 +10598,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -11032,19 +11032,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:55 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -11077,19 +11077,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 04:20 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C9E (19614)
@@ -11114,19 +11114,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 04:40 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CAB (19627)
@@ -11151,19 +11151,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CC2 (19650)
@@ -11189,19 +11189,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:30 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CD6 (19670)
@@ -11228,23 +11228,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CE6 (19686)
@@ -11278,19 +11278,19 @@ Maminka tří chlapců (J. Šulcová) po těžké nemoci, zápalu mozkových bla
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:25 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CF1 (19697)
@@ -11326,19 +11326,19 @@ Pohádku s písničkami i loutkami natočila v roce 1971 režisérka V. Janečko
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:40 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -11371,19 +11371,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 04:25 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CA3 (19619)
@@ -11408,19 +11408,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 04:50 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CB4 (19636)
@@ -11454,19 +11454,19 @@ Byl jedním z nejvýznamnějších přírodovědců v Čechách a zakladatelem v
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:15 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CBE (19646)
@@ -11500,19 +11500,19 @@ Dodekanesos je řecké slovo pro dvanáct ostrovů. Největším z tohoto souost
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:25 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CD6 (19670)
@@ -11537,19 +11537,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CDA (19674)
@@ -11592,19 +11592,19 @@ Andy a Hatty mají plné ruce práce s novou výstavou v oddělení dinosaurů v
     - Descriptor 8: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:05 (MM-DD hh:mm)
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -11638,19 +11638,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:53 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C8C (19596)
@@ -11677,19 +11677,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 04:19 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CB2 (19634)
@@ -11716,19 +11716,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:11 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CC4 (19652)
@@ -11754,19 +11754,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:37 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CD7 (19671)
@@ -11793,19 +11793,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:03 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CE9 (19689)
@@ -11832,23 +11832,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:29 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -11883,23 +11883,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:15 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CE7 (19687)
@@ -11924,15 +11924,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:25 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -11966,19 +11966,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:55 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C91 (19601)
@@ -12003,19 +12003,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 04:25 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CAA (19626)
@@ -12041,15 +12041,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CD7 (19671)
@@ -12074,19 +12074,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CDC (19676)
@@ -12129,19 +12129,19 @@ Andy a Hatty mají plné ruce práce s novou výstavou v oddělení dinosaurů v
     - Descriptor 8: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:05 (MM-DD hh:mm)
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CE4 (19684)
@@ -12175,19 +12175,19 @@ Malá mláďata psounů prériových Aški a Snížek zažívají každý den sp
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:20 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CEC (19692)
@@ -12213,19 +12213,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:30 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CF2 (19698)
@@ -12250,19 +12250,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:40 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -12793,19 +12793,19 @@ Malá mláďata psounů prériových Aški a Snížek zažívají každý den sp
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:20 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CEB (19691)
@@ -12831,19 +12831,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:30 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CF1 (19697)
@@ -12868,19 +12868,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:40 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -12932,19 +12932,19 @@ Veselohru ze studentského prostředí, okořeněnou prázdninovým milostným r
     - Descriptor 8: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:25 (MM-DD hh:mm)
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 12: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D5A (19802)
@@ -12972,15 +12972,15 @@ Hostem Jaromíra Hanzlíka byl v roce 2002 Vlastimil Bedrna (*8. 2. 1929 - +6. 3
       Language: cze
       Text: "na působení v divadle Rokoko a v Divadle Na zábradlí a také na celou řadu hereckých kolegů. Hereckou dráhu Vlastimila Bedrny připomene také celá řada filmových i divadelních ukázek."
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -13006,15 +13006,15 @@ Hostem Jaromíra Hanzlíka byl v roce 2002 Vlastimil Bedrna (*8. 2. 1929 - +6. 3
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -13055,23 +13055,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D0B (19723)
@@ -13096,19 +13096,19 @@ Zvukový popis"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:15 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D14 (19732)
@@ -13143,15 +13143,15 @@ Představte si, děťulata, že Fámula a Tryský objeví v rybníku pod ledem u
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:30 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D57 (19799)
@@ -13186,15 +13186,15 @@ Vláda České socialistick"
       Language: cze
       Text: "zení nosorožce vzácností. - Křest slůněte v pražské ZOO. - Zvířata-lidé-senzace."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -13232,15 +13232,15 @@ Točit klikou filmové kamery venku při patnácti stupních pod nulou nebylo je
       Language: cze
       Text: "vství Evropy v krasobruslení v lednu 1934, kdy na pražském ledě vystoupila i legendární Sonja Henie."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -13279,15 +13279,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D03 (19715)
@@ -13314,19 +13314,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D2A (19754)
@@ -13351,15 +13351,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 08:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D40 (19776)
@@ -13394,19 +13394,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 08:30 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D57 (19799)
@@ -13431,15 +13431,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 09:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D5A (19802)
@@ -13473,15 +13473,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       Language: cze
       Text: " a nakolik prokoukli potěmkinovskou hru, která se s nimi hrála? A kdo to všechno financoval?"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -13521,19 +13521,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:14 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D1C (19740)
@@ -13558,19 +13558,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 09:15 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D26 (19750)
@@ -13595,19 +13595,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 10:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D31 (19761)
@@ -13631,15 +13631,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 08:40 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D4A (19786)
@@ -13665,19 +13665,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:15 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -13712,23 +13712,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+      Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D0B (19723)
@@ -13753,19 +13753,19 @@ Zvukový popis"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:15 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D14 (19732)
@@ -13800,15 +13800,15 @@ Představte si, děťulata, že Fámula a Tryský objeví v rybníku pod ledem u
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:30 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D57 (19799)
@@ -13837,15 +13837,15 @@ Určitě si taky v kině dáváte popcorn a nějakou dobrou limonádu. Jenže dr
       Language: cze
       Text: "ačí kuchyně. Uvidíte, že to není nic složitého a chutná to báječně!"
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -13871,19 +13871,19 @@ Určitě si taky v kině dáváte popcorn a nějakou dobrou limonádu. Jenže dr
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -13915,15 +13915,15 @@ Další kreslený příběh oblíbených galských hrdinů. Autoři Goscinny - U
       Language: cze
       Text: "ska Idefixe. Tentokrát, aby naši kamarádi dokázali, že jsou bohové, musí splnit dvanáct nelehkých úkolů."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -14505,19 +14505,19 @@ Malebné jihočeské městečko leží v ohybu řeky Vltavy, v podhradí původn
       Language: cze
       Text: " tři sta vzorně udržovaných gotických a renesančních budov, a právě proto je Český Krumlov hlavním lákadlem pro zahraniční návštěvníky, kteří se rozhodnou opustit náruč Prahy. Pořadem nás provede herec Miroslav Táborský."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -14551,15 +14551,15 @@ Malebné jihočeské městečko leží v ohybu řeky Vltavy, v podhradí původn
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -14585,15 +14585,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -14634,19 +14634,19 @@ Dynastie Nováků se rozrostla o malého Tomáška. Hudebníci z Martinovy kapel
       Language: cze
       Text: "čková) zase nápadně často dojíždět do Prahy. Lída (H. Maciuchová) se sešla s Emilem (O. Vízner), aby si rozdělili majetek. Vypadá to však, že se manželé mají stále rádi..."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -14692,15 +14692,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
       Language: cze
       Text: " stavebního řízení"
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -14743,15 +14743,15 @@ Ponorka kapitána Dicka O'Kanea objevila v červenci 1944 u pobřeží japonské
       Language: cze
       Text: "louznout a potopit nákladní lodě. Svou myšlenku převedl v dokonalý útok."
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -14795,19 +14795,19 @@ Když byla v roce 1991 Šumava vyhlášena největším českým národním park
       Language: cze
       Text: "stal až do přijetí zákona o národních parcích na jaře roku 2017. Dokument se pokouší o historickou analýzu milníků, které demarkační čáry národního parku Šumava v posledních třech desetiletích proměňovaly a ovlivňovaly."
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -14848,23 +14848,23 @@ Dnešní reportáž bude věnována projektům, které mají jediný cíl - zach
       Language: cze
       Text: "me opuštěné pejsky, které vám Zdeněk Srstka tentokrát nepředstaví sám."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+      Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -14897,15 +14897,15 @@ Dnešní reportáž bude věnována projektům, které mají jediný cíl - zach
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -14929,11 +14929,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -14958,15 +14958,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -14990,11 +14990,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -15040,15 +15040,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
       Language: cze
       Text: " stavebního řízení"
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -15081,11 +15081,11 @@ Připomenutí největších úspěchů československých sportovců na evropsk�
       "Žánr" : "sportovní magazín"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -15111,15 +15111,15 @@ Připomenutí největších úspěchů československých sportovců na evropsk�
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15143,11 +15143,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "16:9"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -15173,15 +15173,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15207,15 +15207,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15248,15 +15248,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15281,11 +15281,11 @@ Skryté titulky"
       "Žánr" : "animovaný / loutkový"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -15316,15 +15316,15 @@ Ahoj, Šikulové, dnes vás zdravíme ze základní školy J. A. Komenského v B
       Language: cze
       Text: "e pilky, kladiva i pilníky. Ze dřeva vykouzlíme svícen, věšáček nebo přívěsek na klíče."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -15355,15 +15355,15 @@ Skryté titulky
       Language: cze
       Text: "motné matičky Země. Kdo natěží nejvíce surovin, nezabloudí v podzemí U6 a správně odpoví i na zvídavé dotazy pana Továrníka, bude mít šanci bojovat o poklad U6."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -15412,15 +15412,15 @@ Na začátku dnešního dílu se seznámíme s Benjaminem, který si přivřel p
       Language: cze
       Text: "erozumíte? No prostě: dostal takovou pětku, až si z toho zlomil ruku."
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -15446,15 +15446,15 @@ Na začátku dnešního dílu se seznámíme s Benjaminem, který si přivřel p
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15479,15 +15479,15 @@ Skryté titulky"
       Text: "4:3
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -16164,19 +16164,19 @@ Pastor Slezské církve evangelické augsburského vyznání v Komorní Lhotce B
       Language: cze
       Text: "žíšovo světlo, ostatně jako už mnohokrát předtím."
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+      Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -16226,15 +16226,15 @@ Publicista Daniel Raus se ve své glose zamýšlí nad tím, jak nám chutná ž
       Language: cze
       Text: "ých kultur a ras a jak je podmíněn reálnou zkušeností s takovýmto soužitím."
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -16280,19 +16280,19 @@ Ve spolupráci s ministerstvem práce a sociálních věcí vznikl cy"
       Language: cze
       Text: "i, ale i úmrtí v rodině mohou způsobit, že úřady zvažují odebrání dítěte do ústavní péče. Vážný zásah do života dítěte by však měl přijít až poté, co jsou vyčerpány všechny možnosti nápravy."
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -16325,15 +16325,15 @@ Ve spolupráci s ministerstvem práce a sociálních věcí vznikl cy"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -16374,19 +16374,19 @@ Otce si zahrál Jiří Zahajský, který by v těchto "
       Language: cze
       Text: "dnech oslavil osmdesáté narozeniny."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -16426,15 +16426,15 @@ Setkat se se strašidlem, to se každému hned tak nepovede. Vy teď tuto možno
       Language: cze
       Text: "ádku, ve které si zahráli A. Pyško, Z. Hadrbolcová, V. Jeníková, letošní jubilant D. Prachař, S. Stašová, S. Nálepková a O. Vízner."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -16473,15 +16473,15 @@ Známou pohádkou o Šípkové Růžence pr"
       Language: cze
       Text: "il), který ji probudí..."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -16533,15 +16533,15 @@ Jen málokteré místo nám poskytlo více informací o životě v Římské ř�
       Language: cze
       Text: "vovaných ve smrtelných pozicích."
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -16585,15 +16585,15 @@ Dokument zachycuje dorostenecké období a hlavně dospívání lvích samců, k
       Language: cze
       Text: "."
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -16633,15 +16633,15 @@ Dlouhá čínská zeď je nejvýznačnější architektonická struktura, která
       Language: cze
       Text: "ství a dodnes má značnou prestiž, zejména v oboru hudby a v oblasti gastronomie. A také v bohatství jeho paláců."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -16674,15 +16674,15 @@ Dlouhá čínská zeď je nejvýznačnější architektonická struktura, která
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -16721,15 +16721,15 @@ Mikuláš Peksa /P"
 -priority a jednotnost zahraniční politiky ČR
 -ekonomická diplomacie, otevírání nových ambasád"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -16754,11 +16754,11 @@ Mikuláš Peksa /P"
       Text: "6:43. Další informace k tématu dodá redaktor ČT Martin Tyburec.
 HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -16792,15 +16792,15 @@ HDTV"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -16826,15 +16826,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -16860,15 +16860,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -16895,19 +16895,19 @@ Skryté titulky"
 Znakový jazyk
 Zvukový popis"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+      Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -16933,15 +16933,15 @@ Zvukový popis"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -16989,19 +16989,19 @@ Otce si zahrál Jiří Zahajský, který by v těchto dnech oslavil osm"
       Language: cze
       Text: "desáté narozeniny."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -17041,15 +17041,15 @@ Setkat se se strašidlem, to se každému hned tak nepovede. Vy teď tuto možno
       Language: cze
       Text: "ádku, ve které si zahráli A. Pyško, Z. Hadrbolcová, V. Jeníková, letošní jubilant D. Prachař, S. Stašová, S. Nálepková a O. Vízner."
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -17080,15 +17080,15 @@ Naši hrdinové skákali z letadla, pátrali po ztraceném v moři, zachraňoval
       Language: cze
       Text: "u, potápěli se se žraloky, plnili všemožné, extrémně náročné disciplíny. Nyní je na čase se dozvdět, kdo z nich si vedl nejlépe. Závěrečný díl první série Hrdinů v akci. Soutěže inspirované skutečnými hrdinskými činy."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -17123,15 +17123,15 @@ Deset úžasných dětských kuchařů čeká další dobrodružství v kuchyni 
       Language: cze
       Text: "teré proslavil sám Gordon Ramsay - proslulou hovězí svíčkovou Wellington. Dvojice kulinářských adeptů si sáhnou na dno svých sil, ale ani to nezachrání před odchodem ze soutěže další dva z nich."
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+      Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -17394,19 +17394,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -17573,19 +17573,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -17748,19 +17748,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -17801,15 +17801,15 @@ Byl přítelem Jana Palacha v době studií v Praze. I na základě jeho činu p
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 18:27 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4AFE (19198)
@@ -17835,19 +17835,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 18:55 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -17875,19 +17875,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -17914,19 +17914,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -17951,15 +17951,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -17984,11 +17984,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -18020,19 +18020,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B58 (19288)
@@ -18072,19 +18072,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -18117,15 +18117,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B84 (19332)
@@ -18161,19 +18161,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:05 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B96 (19350)
@@ -18207,19 +18207,19 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:32 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BAA (19370)
@@ -18243,15 +18243,15 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BBD (19389)
@@ -18276,19 +18276,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:27 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BC8 (19400)
@@ -18315,23 +18315,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:40 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BD5 (19413)
@@ -18355,15 +18355,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BDE (19422)
@@ -18388,15 +18388,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:10 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -18813,15 +18813,15 @@ Klukovský klub Rychlých šípů - Mirek Dušín, Jarka "
       Text: "ch totiž vládne drsný chlapecký gang Vontů...
 Tento film uvádíme k příležitosti 20 let od úmrtí spisovatele a autora knižní série o Rychlých šípech Jaroslava Foglara."
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -18883,15 +18883,15 @@ Dana je snědá Romka. Vyrostla v bílé, adoptivní rodině a náhradní rodič
       Language: cze
       Text: "ku, za vzdělání i za rozhled a také za podporu v hledání biologických kořenů. Prozíravá maminka věděla, že původ bude Danu jednou určitě zajímat a bude důležité jej znát, aby mohla zdravě a bez pochybností žít dál."
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Content (0x54, 84), 2 bytes
@@ -18928,19 +18928,19 @@ Usedněme společně do pomyslného stroje času a vraťme se do dob, kdy naši 
       Language: cze
       Text: "ad praží letní slunce! Po vší té lopotě na nás čeká odměna v podobě krásného pecnu chleba z tradiční pece po dědečkovi."
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -18966,19 +18966,19 @@ Usedněme společně do pomyslného stroje času a vraťme se do dob, kdy naši 
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -19017,19 +19017,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C1E (19486)
@@ -19056,19 +19056,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:43 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C30 (19504)
@@ -19094,19 +19094,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:09 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C42 (19522)
@@ -19133,19 +19133,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:35 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C67 (19559)
@@ -19172,19 +19172,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:27 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -19218,19 +19218,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:53 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C8C (19596)
@@ -19257,19 +19257,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 04:19 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CB2 (19634)
@@ -19296,19 +19296,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:11 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CC4 (19652)
@@ -19334,19 +19334,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:37 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CD7 (19671)
@@ -19373,19 +19373,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:03 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CE9 (19689)
@@ -19412,23 +19412,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:29 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -19461,15 +19461,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D03 (19715)
@@ -19496,19 +19496,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D2A (19754)
@@ -19533,15 +19533,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 08:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D40 (19776)
@@ -19576,19 +19576,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 08:30 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D57 (19799)
@@ -19613,15 +19613,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 09:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D5A (19802)
@@ -19655,15 +19655,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       Language: cze
       Text: " a nakolik prokoukli potěmkinovskou hru, která se s nimi hrála? A kdo to všechno financoval?"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -19696,15 +19696,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -19728,11 +19728,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -19757,15 +19757,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -19789,11 +19789,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -19839,15 +19839,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
       Language: cze
       Text: " stavebního řízení"
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -19880,15 +19880,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -19927,15 +19927,15 @@ Mikuláš Peksa /P"
 -priority a jednotnost zahraniční politiky ČR
 -ekonomická diplomacie, otevírání nových ambasád"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -19960,11 +19960,11 @@ Mikuláš Peksa /P"
       Text: "6:43. Další informace k tématu dodá redaktor ČT Martin Tyburec.
 HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -19998,19 +19998,19 @@ HDTV"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20036,19 +20036,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20073,15 +20073,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -20107,19 +20107,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20153,19 +20153,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20189,11 +20189,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -20220,19 +20220,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20257,15 +20257,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -20290,15 +20290,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -20324,19 +20324,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20360,11 +20360,11 @@ Skryté titulky"
       "Žánr" : "zpravodajský magazín"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -20397,15 +20397,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -20435,15 +20435,15 @@ Skryté titulky"
 HDTV
 Skryté titulky"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20469,15 +20469,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -20501,11 +20501,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -20531,15 +20531,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -20566,19 +20566,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20602,11 +20602,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -20647,15 +20647,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
 -zákon o liniových stavbách
 -délka stavebního řízení"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20729,19 +20729,19 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20782,15 +20782,15 @@ Byl přítelem Jana Palacha v době studií v Praze. I na základě jeho činu p
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 18:27 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4AFE (19198)
@@ -20816,19 +20816,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 18:55 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -20856,19 +20856,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20895,19 +20895,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -20932,15 +20932,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -20965,11 +20965,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -21001,19 +21001,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B58 (19288)
@@ -21053,19 +21053,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -21098,15 +21098,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B84 (19332)
@@ -21142,19 +21142,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:05 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B96 (19350)
@@ -21188,19 +21188,19 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:32 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BAA (19370)
@@ -21224,15 +21224,15 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BBD (19389)
@@ -21257,19 +21257,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:27 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BC8 (19400)
@@ -21296,23 +21296,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:40 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BD5 (19413)
@@ -21336,15 +21336,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BDE (19422)
@@ -21369,15 +21369,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:10 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -21410,19 +21410,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C1E (19486)
@@ -21449,19 +21449,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:43 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C30 (19504)
@@ -21487,19 +21487,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:09 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C42 (19522)
@@ -21526,19 +21526,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:35 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C67 (19559)
@@ -21565,19 +21565,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:27 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -21611,19 +21611,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:53 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C8C (19596)
@@ -21650,19 +21650,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 04:19 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CB2 (19634)
@@ -21689,19 +21689,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:11 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CC4 (19652)
@@ -21727,19 +21727,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:37 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CD7 (19671)
@@ -21766,19 +21766,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:03 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CE9 (19689)
@@ -21805,23 +21805,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:29 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -21854,15 +21854,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D03 (19715)
@@ -21889,19 +21889,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D2A (19754)
@@ -21926,15 +21926,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 08:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D40 (19776)
@@ -21969,19 +21969,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 08:30 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D57 (19799)
@@ -22006,15 +22006,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 09:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D5A (19802)
@@ -22048,15 +22048,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       Language: cze
       Text: " a nakolik prokoukli potěmkinovskou hru, která se s nimi hrála? A kdo to všechno financoval?"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -22089,15 +22089,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -22121,11 +22121,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -22150,15 +22150,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -22182,11 +22182,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -22232,15 +22232,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
       Language: cze
       Text: " stavebního řízení"
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -22273,15 +22273,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -22320,15 +22320,15 @@ Mikuláš Peksa /P"
 -priority a jednotnost zahraniční politiky ČR
 -ekonomická diplomacie, otevírání nových ambasád"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -22353,11 +22353,11 @@ Mikuláš Peksa /P"
       Text: "6:43. Další informace k tématu dodá redaktor ČT Martin Tyburec.
 HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -22391,19 +22391,19 @@ HDTV"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -22429,19 +22429,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -22466,15 +22466,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -22500,19 +22500,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -22546,19 +22546,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -22582,11 +22582,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -22613,19 +22613,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -22650,15 +22650,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -22683,15 +22683,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -22717,19 +22717,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -22753,11 +22753,11 @@ Skryté titulky"
       "Žánr" : "zpravodajský magazín"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -22790,15 +22790,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -22828,15 +22828,15 @@ Skryté titulky"
 HDTV
 Skryté titulky"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -22862,15 +22862,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -22894,11 +22894,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -22924,15 +22924,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -22959,19 +22959,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -22995,11 +22995,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -23040,15 +23040,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
 -zákon o liniových stavbách
 -délka stavebního řízení"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -23088,19 +23088,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -23167,19 +23167,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -23258,19 +23258,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -23334,15 +23334,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -23513,19 +23513,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -23566,15 +23566,15 @@ Byl přítelem Jana Palacha v době studií v Praze. I na základě jeho činu p
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 18:27 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4AFE (19198)
@@ -23600,19 +23600,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 18:55 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -23640,19 +23640,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -23679,19 +23679,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -23716,15 +23716,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -23749,11 +23749,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -23781,19 +23781,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: PDC (0x69, 105), 3 bytes
@@ -23835,19 +23835,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
     - Descriptor 7: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 11: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -23880,15 +23880,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B84 (19332)
@@ -23924,19 +23924,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:05 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4B96 (19350)
@@ -23970,19 +23970,19 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 22:32 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BAA (19370)
@@ -24006,15 +24006,15 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BBD (19389)
@@ -24039,19 +24039,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:27 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BC8 (19400)
@@ -24078,23 +24078,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-19 23:40 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BD5 (19413)
@@ -24118,15 +24118,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4BDE (19422)
@@ -24151,15 +24151,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 00:10 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -24192,19 +24192,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C1E (19486)
@@ -24231,19 +24231,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 01:43 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C30 (19504)
@@ -24269,19 +24269,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:09 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C42 (19522)
@@ -24308,19 +24308,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 02:35 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C67 (19559)
@@ -24347,19 +24347,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:27 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -24393,19 +24393,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 03:53 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4C8C (19596)
@@ -24432,19 +24432,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 04:19 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CB2 (19634)
@@ -24471,19 +24471,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:11 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CC4 (19652)
@@ -24509,19 +24509,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 05:37 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CD7 (19671)
@@ -24548,19 +24548,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:03 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4CE9 (19689)
@@ -24587,23 +24587,23 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 06:29 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
 
@@ -24636,15 +24636,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D03 (19715)
@@ -24671,19 +24671,19 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 07:05 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D2A (19754)
@@ -24708,15 +24708,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 08:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D40 (19776)
@@ -24751,19 +24751,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
     - Descriptor 6: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 08:30 (MM-DD hh:mm)
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 8: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 9: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 10: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D57 (19799)
@@ -24788,15 +24788,15 @@ Skryté titulky"
     - Descriptor 4: PDC (0x69, 105), 3 bytes
       Programme Identification Label: 01-20 09:00 (MM-DD hh:mm)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0302 (Associated EBU Teletext)
+      Content/type: 0xF302 (Associated EBU Teletext)
       Component tag: 0x04 (4)
       Language: cze
   - Event Id: 0x4D5A (19802)
@@ -24830,15 +24830,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       Language: cze
       Text: " a nakolik prokoukli potěmkinovskou hru, která se s nimi hrála? A kdo to všechno financoval?"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 7: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -24871,15 +24871,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -24903,11 +24903,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -24932,15 +24932,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -24964,11 +24964,11 @@ Skryté titulky"
       "Žánr" : "diskuze / rozhovor"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -25014,15 +25014,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
       Language: cze
       Text: " stavebního řízení"
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 6: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -25055,15 +25055,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -25102,15 +25102,15 @@ Mikuláš Peksa /P"
 -priority a jednotnost zahraniční politiky ČR
 -ekonomická diplomacie, otevírání nových ambasád"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -25135,11 +25135,11 @@ Mikuláš Peksa /P"
       Text: "6:43. Další informace k tématu dodá redaktor ČT Martin Tyburec.
 HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -25173,19 +25173,19 @@ HDTV"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -25211,19 +25211,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -25248,15 +25248,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -25282,19 +25282,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -25328,19 +25328,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -25364,11 +25364,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -25395,19 +25395,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -25432,15 +25432,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -25465,15 +25465,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -25499,19 +25499,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -25535,11 +25535,11 @@ Skryté titulky"
       "Žánr" : "zpravodajský magazín"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -25572,15 +25572,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -25610,15 +25610,15 @@ Skryté titulky"
 HDTV
 Skryté titulky"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -25644,15 +25644,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -25676,11 +25676,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -25706,15 +25706,15 @@ Skryté titulky"
       Text: "HDTV
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -25741,19 +25741,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+      Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
       Component tag: 0x07 (7)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -25777,11 +25777,11 @@ Skryté titulky"
       "Žánr" : "zprávy, počasí"
       Text: "HDTV"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -25822,15 +25822,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
 -zákon o liniových stavbách
 -délka stavebního řízení"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: cze
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: cze
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x04 (4)
       Language: cze
     - Descriptor 6: Content (0x54, 84), 2 bytes

--- a/reference/test-038/test-038.tstables.txt
+++ b/reference/test-038/test-038.tstables.txt
@@ -40,23 +40,23 @@ Velká zábavná show, ve které nic není nemožné. Svou pohotovost tentokrát
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:00 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -122,19 +122,19 @@ V noci, kdy umírá hoteliér Eduard Sacher, dojde také k únosu jedenáctilet�
       - Descriptor 11: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:15 (MM-DD hh:mm)
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 13: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 14: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 15: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -195,19 +195,19 @@ Mezinárodně oceněný výpravný seriál tvůrců Toma Tykwera (Lola běží o
       - Descriptor 9: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:50 (MM-DD hh:mm)
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 13: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -268,19 +268,19 @@ Skryté titulky
       - Descriptor 11: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:40 (MM-DD hh:mm)
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 13: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 14: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 15: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -314,15 +314,15 @@ Skryté titulky
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -354,19 +354,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -400,15 +400,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:25 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -439,15 +439,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 22:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -505,15 +505,15 @@ Na předávání křišťálových trofejí s grafikou jedné z Janáčko"
       - Descriptor 9: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:20 (MM-DD hh:mm)
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -572,15 +572,15 @@ Povolání: reportér patří k divácky nejvstřícnějším dílům z Antonion
       - Descriptor 10: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:40 (MM-DD hh:mm)
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 13: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -986,15 +986,15 @@ Povolání: reportér patří k divácky nejvstřícnějším dílům z Antonion
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -1026,19 +1026,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -1305,15 +1305,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -1345,19 +1345,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -1392,19 +1392,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -1450,19 +1450,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       - Descriptor 7: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -1722,19 +1722,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -1780,19 +1780,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       - Descriptor 7: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -1890,19 +1890,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       - Descriptor 7: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 1:
@@ -1933,15 +1933,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 22:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
 
@@ -2367,19 +2367,19 @@ Dnešní díl je poněkud atypický. Vracíme se k některým zajímavým příb
         Language: cze
         Text: " je upřímně překvapen. Právě na těchto příbězích je vidět obrovské úsilí a maximální snahu všech zúčastněných o vyladění vzájemného soužití."
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 12: Content (0x54, 84), 2 bytes
@@ -2418,15 +2418,15 @@ Začátkem roku odlehčíme našim peněženkám, což ovšem neznamená, že se
         Language: cze
         Text: "obalované v ořechách a rozinkách marinovaných v rumu."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -2458,19 +2458,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 18:55 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 41:
@@ -2538,19 +2538,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -2577,19 +2577,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -2631,23 +2631,23 @@ Velká zábavná show, ve které nic není nemožné. Svou pohotovost tentokrát
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:00 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4B60 (19296)
@@ -2707,19 +2707,19 @@ V noci, kdy umírá hoteliér Eduard Sacher, dojde také k únosu jedenáctilet�
       - Descriptor 11: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:15 (MM-DD hh:mm)
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 13: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 14: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 15: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 49:
@@ -2791,15 +2791,15 @@ V noci, kdy umírá hoteliér Eduard Sacher, dojde také k únosu jedenáctilet�
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 22:54 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BA6 (19366)
@@ -2837,19 +2837,19 @@ Manažer velké nadnárodní společnosti Wallace Avery (C. Firth) je ve všech 
       - Descriptor 7: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 22:55 (MM-DD hh:mm)
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BE6 (19430)
@@ -2874,19 +2874,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 00:25 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BF9 (19449)
@@ -2911,19 +2911,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 00:50 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 57:
@@ -2996,19 +2996,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 01:15 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C1B (19483)
@@ -3033,19 +3033,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 01:35 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C2B (19499)
@@ -3070,19 +3070,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 02:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C3C (19516)
@@ -3107,19 +3107,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 02:25 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C7D (19581)
@@ -3144,19 +3144,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 03:55 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 65:
@@ -3229,19 +3229,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 04:20 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C9E (19614)
@@ -3266,19 +3266,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 04:40 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CAB (19627)
@@ -3303,19 +3303,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 05:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CC2 (19650)
@@ -3341,19 +3341,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 05:30 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CD6 (19670)
@@ -3380,23 +3380,23 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CE6 (19686)
@@ -3430,19 +3430,19 @@ Maminka tří chlapců (J. Šulcová) po těžké nemoci, zápalu mozkových bla
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:25 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CF1 (19697)
@@ -3478,19 +3478,19 @@ Pohádku s písničkami i loutkami natočila v roce 1971 režisérka V. Janečko
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:40 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 73:
@@ -3582,19 +3582,19 @@ Veselohru ze studentského prostředí, okořeněnou prázdninovým milostným r
       - Descriptor 8: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:25 (MM-DD hh:mm)
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D5A (19802)
@@ -3622,15 +3622,15 @@ Hostem Jaromíra Hanzlíka byl v roce 2002 Vlastimil Bedrna (*8. 2. 1929 - +6. 3
         Language: cze
         Text: "na působení v divadle Rokoko a v Divadle Na zábradlí a také na celou řadu hereckých kolegů. Hereckou dráhu Vlastimila Bedrny připomene také celá řada filmových i divadelních ukázek."
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -3656,15 +3656,15 @@ Hostem Jaromíra Hanzlíka byl v roce 2002 Vlastimil Bedrna (*8. 2. 1929 - +6. 3
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -3738,15 +3738,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -3772,15 +3772,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -3821,19 +3821,19 @@ Dynastie Nováků se rozrostla o malého Tomáška. Hudebníci z Martinovy kapel
         Language: cze
         Text: "čková) zase nápadně často dojíždět do Prahy. Lída (H. Maciuchová) se sešla s Emilem (O. Vízner), aby si rozdělili majetek. Vypadá to však, že se manželé mají stále rádi..."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -3879,15 +3879,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
         Language: cze
         Text: " stavebního řízení"
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -3960,15 +3960,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -4009,19 +4009,19 @@ Otce si zahrál Jiří Zahajský, který by v těchto "
         Language: cze
         Text: "dnech oslavil osmdesáté narozeniny."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -4061,15 +4061,15 @@ Setkat se se strašidlem, to se každému hned tak nepovede. Vy teď tuto možno
         Language: cze
         Text: "ádku, ve které si zahráli A. Pyško, Z. Hadrbolcová, V. Jeníková, letošní jubilant D. Prachař, S. Stašová, S. Nálepková a O. Vízner."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -4108,15 +4108,15 @@ Známou pohádkou o Šípkové Růžence pr"
         Language: cze
         Text: "il), který ji probudí..."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -4166,15 +4166,15 @@ Klukovský klub Rychlých šípů - Mirek Dušín, Jarka "
         Text: "ch totiž vládne drsný chlapecký gang Vontů...
 Tento film uvádíme k příležitosti 20 let od úmrtí spisovatele a autora knižní série o Rychlých šípech Jaroslava Foglara."
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -4270,15 +4270,15 @@ Dana je snědá Romka. Vyrostla v bílé, adoptivní rodině a náhradní rodič
         Language: cze
         Text: "ku, za vzdělání i za rozhled a také za podporu v hledání biologických kořenů. Prozíravá maminka věděla, že původ bude Danu jednou určitě zajímat a bude důležité jej znát, aby mohla zdravě a bez pochybností žít dál."
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Content (0x54, 84), 2 bytes
@@ -4315,19 +4315,19 @@ Usedněme společně do pomyslného stroje času a vraťme se do dob, kdy naši 
         Language: cze
         Text: "ad praží letní slunce! Po vší té lopotě na nás čeká odměna v podobě krásného pecnu chleba z tradiční pece po dědečkovi."
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -4353,19 +4353,19 @@ Usedněme společně do pomyslného stroje času a vraťme se do dob, kdy naši 
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -4439,19 +4439,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -4478,19 +4478,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -4514,11 +4514,11 @@ Skryté titulky"
         "Žánr" : "kviz / soutěž"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -4564,19 +4564,19 @@ Komisař Vašátko (V. Preiss) se na dovolené na horské chatě potká s malí�
         Language: cze
         Text: "olicie se kvůli vichřici nemůže do chaty dostat, a tak se vyšetřování ujímá přítomný a zkušený komisař Vašátko. Chata je plná lidí, kteří mají silné motivy k vraždě..."
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -4602,15 +4602,15 @@ Komisař Vašátko (V. Preiss) se na dovolené na horské chatě potká s malí�
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -4646,19 +4646,19 @@ Nová talkshow Vaška Kopty představí známé tváře úplně jinak, než jsme
         Language: cze
         Text: "edničce. Byla někdy biatlonistka ve výslužbě Gábina Koukalová na rybách? Kam nejdál dojel režisér Honza Hřebejk na běžkách? A nosí nejslavnější český rybář Jakub Vágner někdy pruhované triko? Uvidíte!"
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -4730,11 +4730,11 @@ Nová talkshow Vaška Kopty představí známé tváře úplně jinak, než jsme
         "Žánr" : "kviz / soutěž"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -4778,15 +4778,15 @@ S kapitánem Exnerem, pověstným el"
         Language: cze
         Text: "íra Kratinu a Karla Augustu."
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -4824,15 +4824,15 @@ Zemře-li násilnou smrtí mladá, půvabná žena, u níž nelze ex post vylou�
         Language: cze
         Text: " horákyni - jaksi konalo i nekonalo..."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -5124,15 +5124,15 @@ Až z druhého konce planety jezdí do Botswany lidé, aby obdivovali tamní př
         Text: "baby. 
 Botswana si zaslouží stále více pozornosti. Den po dni se obrací zády k historii chudé země bez jakékoli perspektivy."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -5156,11 +5156,11 @@ Botswana si zaslouží stále více pozornosti. Den po dni se obrací zády k hi
         "Žánr" : "animovaný / loutkový"
         Text: "4:3"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -5186,19 +5186,19 @@ Botswana si zaslouží stále více pozornosti. Den po dni se obrací zády k hi
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -5298,15 +5298,15 @@ Mikulovský židovský hřbitov, významný nejen pro svou umělecko-historickou
         Language: cze
         Text: " zasvěceným průvodcem po dané lokalitě místní odborník, který je zapojen do správy a péče o židovské památky. V Mikulově jím bude malířka a galeristka Sylva Chludilová."
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Content (0x54, 84), 2 bytes
@@ -5331,15 +5331,15 @@ Mikulovský židovský hřbitov, významný nejen pro svou umělecko-historickou
         Text: "HDTV
 Znakový jazyk"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+        Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -5401,15 +5401,15 @@ Výpravný šestnáctidílný seriál se strhující atmosférou vychází z det
         Language: cze
         Text: "s a v roli zasloužilého policisty Bruna Woltera renomovaného německého herce Petera Kurtha, kterého čeští diváci mohou znát na příklad z titulní role ve snímku Schmitke."
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Content (0x54, 84), 2 bytes
@@ -5467,19 +5467,19 @@ Mezinárodně oceněný výpravný seriál tvůrců Toma Tykwera (Lola běží o
       - Descriptor 9: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:50 (MM-DD hh:mm)
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 13: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 50:
@@ -5540,19 +5540,19 @@ Skryté titulky
       - Descriptor 11: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:40 (MM-DD hh:mm)
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 13: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 14: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 15: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 51:
@@ -5644,19 +5644,19 @@ Píše se rok 1941. Britové prohráli leteckou bitvu o Bri"
       - Descriptor 11: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 23:35 (MM-DD hh:mm)
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 13: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 14: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 15: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 57:
@@ -5744,23 +5744,23 @@ V dalším díle dokumentárního cyklu se seznámíme s vápenci a kalcitovými
       - Descriptor 7: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 01:05 (MM-DD hh:mm)
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C19 (19481)
@@ -5802,19 +5802,19 @@ Královské dvory a rezidence v jagellonské Evropě 1386-1572 ukazují historii
       - Descriptor 8: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 01:35 (MM-DD hh:mm)
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C2E (19502)
@@ -5839,19 +5839,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 02:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C40 (19520)
@@ -5876,19 +5876,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 02:30 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C4A (19530)
@@ -5913,19 +5913,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 02:45 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C5D (19549)
@@ -5951,23 +5951,23 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 03:10 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C6A (19562)
@@ -5993,23 +5993,23 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 03:30 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 65:
@@ -6040,19 +6040,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 03:55 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 66:
@@ -6119,19 +6119,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 04:25 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CA3 (19619)
@@ -6156,19 +6156,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 04:50 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CB4 (19636)
@@ -6202,19 +6202,19 @@ Byl jedním z nejvýznamnějších přírodovědců v Čechách a zakladatelem v
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 05:15 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CBE (19646)
@@ -6248,19 +6248,19 @@ Dodekanesos je řecké slovo pro dvanáct ostrovů. Největším z tohoto souost
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 05:25 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CD6 (19670)
@@ -6285,19 +6285,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CDA (19674)
@@ -6340,19 +6340,19 @@ Andy a Hatty mají plné ruce práce s novou výstavou v oddělení dinosaurů v
       - Descriptor 8: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:05 (MM-DD hh:mm)
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 73:
@@ -6392,19 +6392,19 @@ Malá mláďata psounů prériových Aški a Snížek zažívají každý den sp
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:20 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CEB (19691)
@@ -6430,19 +6430,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:30 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CF1 (19697)
@@ -6467,19 +6467,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:40 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 74:
@@ -6548,23 +6548,23 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D0B (19723)
@@ -6589,19 +6589,19 @@ Zvukový popis"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:15 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D14 (19732)
@@ -6636,15 +6636,15 @@ Představte si, děťulata, že Fámula a Tryský objeví v rybníku pod ledem u
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:30 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D57 (19799)
@@ -6679,15 +6679,15 @@ Vláda České socialistick"
         Language: cze
         Text: "zení nosorožce vzácností. - Křest slůněte v pražské ZOO. - Zvířata-lidé-senzace."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -6725,15 +6725,15 @@ Točit klikou filmové kamery venku při patnácti stupních pod nulou nebylo je
         Language: cze
         Text: "vství Evropy v krasobruslení v lednu 1934, kdy na pražském ledě vystoupila i legendární Sonja Henie."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -6778,19 +6778,19 @@ Malebné jihočeské městečko leží v ohybu řeky Vltavy, v podhradí původn
         Language: cze
         Text: " tři sta vzorně udržovaných gotických a renesančních budov, a právě proto je Český Krumlov hlavním lákadlem pro zahraniční návštěvníky, kteří se rozhodnou opustit náruč Prahy. Pořadem nás provede herec Miroslav Táborský."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -6867,15 +6867,15 @@ Ponorka kapitána Dicka O'Kanea objevila v červenci 1944 u pobřeží japonské
         Language: cze
         Text: "louznout a potopit nákladní lodě. Svou myšlenku převedl v dokonalý útok."
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -6919,19 +6919,19 @@ Když byla v roce 1991 Šumava vyhlášena největším českým národním park
         Language: cze
         Text: "stal až do přijetí zákona o národních parcích na jaře roku 2017. Dokument se pokouší o historickou analýzu milníků, které demarkační čáry národního parku Šumava v posledních třech desetiletích proměňovaly a ovlivňovaly."
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -6972,23 +6972,23 @@ Dnešní reportáž bude věnována projektům, které mají jediný cíl - zach
         Language: cze
         Text: "me opuštěné pejsky, které vám Zdeněk Srstka tentokrát nepředstaví sám."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+        Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -7030,19 +7030,19 @@ Pastor Slezské církve evangelické augsburského vyznání v Komorní Lhotce B
         Language: cze
         Text: "žíšovo světlo, ostatně jako už mnohokrát předtím."
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+        Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -7092,15 +7092,15 @@ Publicista Daniel Raus se ve své glose zamýšlí nad tím, jak nám chutná ž
         Language: cze
         Text: "ých kultur a ras a jak je podmíněn reálnou zkušeností s takovýmto soužitím."
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -7146,19 +7146,19 @@ Ve spolupráci s ministerstvem práce a sociálních věcí vznikl cy"
         Language: cze
         Text: "i, ale i úmrtí v rodině mohou způsobit, že úřady zvažují odebrání dítěte do ústavní péče. Vážný zásah do života dítěte by však měl přijít až poté, co jsou vyčerpány všechny možnosti nápravy."
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -7244,15 +7244,15 @@ Jen málokteré místo nám poskytlo více informací o životě v Římské ř�
         Language: cze
         Text: "vovaných ve smrtelných pozicích."
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -7296,15 +7296,15 @@ Dokument zachycuje dorostenecké období a hlavně dospívání lvích samců, k
         Language: cze
         Text: "."
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -7344,15 +7344,15 @@ Dlouhá čínská zeď je nejvýznačnější architektonická struktura, která
         Language: cze
         Text: "ství a dodnes má značnou prestiž, zejména v oboru hudby a v oblasti gastronomie. A také v bohatství jeho paláců."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -7425,15 +7425,15 @@ Dlouhá čínská zeď je nejvýznačnější architektonická struktura, která
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -7506,15 +7506,15 @@ Skryté titulky"
         Text: "HDTV
 Znakový jazyk"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+        Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -7567,15 +7567,15 @@ Western Strom na věšení (1959) vznikl podle stejnojmenné novely Dorothy M. J
         Language: cze
         Text: "í onemocněl, takže za něho musel anonymně zaskočit právě Karl Malden. Snímek se odehrává v Montaně, ale natáčel se v horské krajině poblíž města Yakima ve státě Washington. Titulní písnička byla nominována na Oscara."
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Content (0x54, 84), 2 bytes
@@ -7622,15 +7622,15 @@ Ačkoli dobové ohlasy filmu kultovního režiséra Johna Carpentera vytýkaly, 
         Language: cze
         Text: " houstnoucí napětí i krvavé surové scény ukazující, jak invazivní organismus se svými hostiteli nakládá."
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -7719,15 +7719,15 @@ Staneme se svědky setká"
         Language: cze
         Text: "církví po desetiletí praktikovaná metoda, jak provinilce úspěšně dostat do bezpečí?"
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -7773,15 +7773,15 @@ Tento díl je věnován období, kdy se rasistické zákony o říšském státn
         Language: cze
         Text: "žení proti Sovětskému svazu se protahuje a pohotovostní oddíly vraždí i ženy a děti."
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -8056,19 +8056,19 @@ Tento díl je věnován období, kdy se rasistické zákony o říšském státn
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -8109,15 +8109,15 @@ Byl přítelem Jana Palacha v době studií v Praze. I na základě jeho činu p
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 18:27 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4AFE (19198)
@@ -8143,19 +8143,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 18:55 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 41:
@@ -8223,19 +8223,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -8262,19 +8262,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -8299,15 +8299,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -8332,11 +8332,11 @@ Skryté titulky"
         "Žánr" : "diskuze / rozhovor"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -8364,19 +8364,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: PDC (0x69, 105), 3 bytes
@@ -8418,19 +8418,19 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
       - Descriptor 7: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:05 (MM-DD hh:mm)
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 49:
@@ -8503,15 +8503,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 22:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4B84 (19332)
@@ -8547,19 +8547,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 22:05 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4B96 (19350)
@@ -8593,19 +8593,19 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 22:32 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BAA (19370)
@@ -8629,15 +8629,15 @@ Napadl sníh a v polovině prosince doprava na D1 několikrát zkolabovala. V as
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 23:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BBD (19389)
@@ -8662,19 +8662,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 23:27 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BC8 (19400)
@@ -8701,23 +8701,23 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 23:40 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BD5 (19413)
@@ -8741,15 +8741,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 00:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BDE (19422)
@@ -8774,15 +8774,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 00:10 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 57:
@@ -8855,19 +8855,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 01:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C1E (19486)
@@ -8894,19 +8894,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 01:43 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C30 (19504)
@@ -8932,19 +8932,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 02:09 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C42 (19522)
@@ -8971,19 +8971,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 02:35 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C67 (19559)
@@ -9010,19 +9010,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 03:27 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 65:
@@ -9096,19 +9096,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 03:53 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C8C (19596)
@@ -9135,19 +9135,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 04:19 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CB2 (19634)
@@ -9174,19 +9174,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 05:11 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CC4 (19652)
@@ -9212,19 +9212,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 05:37 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CD7 (19671)
@@ -9251,19 +9251,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:03 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CE9 (19689)
@@ -9290,23 +9290,23 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:29 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 73:
@@ -9379,15 +9379,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D03 (19715)
@@ -9414,19 +9414,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D2A (19754)
@@ -9451,15 +9451,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 08:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D40 (19776)
@@ -9494,19 +9494,19 @@ Zatímco dnes sílí hlasy proti užívání plastů a výzvy k omezení jejich 
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 08:30 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D57 (19799)
@@ -9531,15 +9531,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 09:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D5A (19802)
@@ -9573,15 +9573,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
         Language: cze
         Text: " a nakolik prokoukli potěmkinovskou hru, která se s nimi hrála? A kdo to všechno financoval?"
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -9654,15 +9654,15 @@ Po zrodu železné opony neutíkali lidé pouze z Československa na západ, ale
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -9686,11 +9686,11 @@ Skryté titulky"
         "Žánr" : "diskuze / rozhovor"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -9715,15 +9715,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -9747,11 +9747,11 @@ Skryté titulky"
         "Žánr" : "diskuze / rozhovor"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -9797,15 +9797,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
         Language: cze
         Text: " stavebního řízení"
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -9878,15 +9878,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -9925,15 +9925,15 @@ Mikuláš Peksa /P"
 -priority a jednotnost zahraniční politiky ČR
 -ekonomická diplomacie, otevírání nových ambasád"
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -9958,11 +9958,11 @@ Mikuláš Peksa /P"
         Text: "6:43. Další informace k tématu dodá redaktor ČT Martin Tyburec.
 HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -10036,19 +10036,19 @@ HDTV"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -10074,19 +10074,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -10111,15 +10111,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -10145,19 +10145,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -10231,19 +10231,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -10267,11 +10267,11 @@ Skryté titulky"
         "Žánr" : "zprávy, počasí"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -10298,19 +10298,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -10335,15 +10335,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -10368,15 +10368,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -10402,19 +10402,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -10438,11 +10438,11 @@ Skryté titulky"
         "Žánr" : "zpravodajský magazín"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -10515,15 +10515,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -10553,15 +10553,15 @@ Skryté titulky"
 HDTV
 Skryté titulky"
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -10587,15 +10587,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -10619,11 +10619,11 @@ Skryté titulky"
         "Žánr" : "zprávy, počasí"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -10649,15 +10649,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -10684,19 +10684,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -10720,11 +10720,11 @@ Skryté titulky"
         "Žánr" : "zprávy, počasí"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -10765,15 +10765,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
 -zákon o liniových stavbách
 -délka stavebního řízení"
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -11048,15 +11048,15 @@ Miloslav Kala, prezident Nejvyššího kontrolního úřadu
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -11082,15 +11082,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -11163,15 +11163,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -11202,15 +11202,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:25 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 49:
@@ -11283,15 +11283,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 22:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4B91 (19345)
@@ -11317,15 +11317,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 22:25 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BB6 (19382)
@@ -11351,19 +11351,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 23:15 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BF6 (19446)
@@ -11389,15 +11389,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 00:45 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C00 (19456)
@@ -11423,19 +11423,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 01:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 57:
@@ -11510,19 +11510,19 @@ Zvukový popis"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 02:40 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C54 (19540)
@@ -11548,15 +11548,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 03:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 65:
@@ -11631,23 +11631,23 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:15 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CE7 (19687)
@@ -11672,15 +11672,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:25 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 73:
@@ -11754,19 +11754,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:14 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D1C (19740)
@@ -11791,19 +11791,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 09:15 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D26 (19750)
@@ -11828,19 +11828,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 10:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D31 (19761)
@@ -11864,15 +11864,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 08:40 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D4A (19786)
@@ -11898,19 +11898,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:15 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 81:
@@ -11977,11 +11977,11 @@ Připomenutí největších úspěchů československých sportovců na evropsk�
         "Žánr" : "sportovní magazín"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -12007,15 +12007,15 @@ Připomenutí největších úspěchů československých sportovců na evropsk�
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12039,11 +12039,11 @@ Skryté titulky"
         "Žánr" : "zprávy, počasí"
         Text: "16:9"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -12069,15 +12069,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12103,15 +12103,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12185,15 +12185,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12219,15 +12219,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12253,15 +12253,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12288,19 +12288,19 @@ Skryté titulky"
 Znakový jazyk
 Zvukový popis"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0330 (Open (in-vision) sign language interpretation for the deaf)
+        Content/type: 0xF330 (Open (in-vision) sign language interpretation for the deaf)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -12326,15 +12326,15 @@ Zvukový popis"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12407,15 +12407,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12488,15 +12488,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12521,15 +12521,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12602,15 +12602,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12636,15 +12636,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12670,15 +12670,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12704,15 +12704,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -12997,15 +12997,15 @@ Deset úžasných dětských kuchařů čeká další dobrodružství v kuchyni 
         Language: cze
         Text: "dání: připravit jídlo, které proslavil sám Gordon Ramsay - proslulou hovězí svíčkovou Wellington. Dvojice kulinářských adeptů si sáhnou na dno svých sil, ale ani to nezachrání před odchodem ze soutěže další dva z nich."
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -13031,15 +13031,15 @@ Deset úžasných dětských kuchařů čeká další dobrodružství v kuchyni 
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -13063,11 +13063,11 @@ Skryté titulky"
         "Žánr" : "vzdělávací pořad pro děti"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -13091,11 +13091,11 @@ Skryté titulky"
         "Žánr" : "animovaný / loutkový"
         Text: "4:3"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -13120,15 +13120,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -13201,15 +13201,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -13235,15 +13235,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -13267,11 +13267,11 @@ Skryté titulky"
         "Žánr" : "animovaný / loutkový"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -13298,19 +13298,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -13365,15 +13365,15 @@ Na předávání křišťálových trofejí s grafikou jedné z Janáčko"
       - Descriptor 9: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 20:20 (MM-DD hh:mm)
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 49:
@@ -13474,15 +13474,15 @@ Povolání: reportér patří k divácky nejvstřícnějším dílům z Antonion
       - Descriptor 10: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 21:40 (MM-DD hh:mm)
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 13: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4BCA (19402)
@@ -13516,15 +13516,15 @@ Záznam vystoupení The Killers v Royal Albert Hall vznikl během natáčení dv
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-19 23:45 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 57:
@@ -13605,15 +13605,15 @@ Běžnou ranní rutinu, zahrnující Jezovy svérázné projevy osobní svobody 
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 00:40 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C06 (19462)
@@ -13652,19 +13652,19 @@ Frontman AC/DC Brian Johnson navštěvuje dům zpěváka The Who Rogera Daltreyh
       - Descriptor 7: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 01:10 (MM-DD hh:mm)
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C26 (19494)
@@ -13699,19 +13699,19 @@ Autor triptychu "Ruské umění" Andrew Graham Dixon připomíná, že bývalá 
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 01:55 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C4B (19531)
@@ -13735,15 +13735,15 @@ Autor triptychu "Ruské umění" Andrew Graham Dixon připomíná, že bývalá 
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 02:45 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C54 (19540)
@@ -13768,19 +13768,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 03:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 65:
@@ -13854,19 +13854,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 03:55 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4C91 (19601)
@@ -13891,19 +13891,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 04:25 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CAA (19626)
@@ -13929,15 +13929,15 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 05:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CD7 (19671)
@@ -13962,19 +13962,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:00 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CDC (19676)
@@ -14017,19 +14017,19 @@ Andy a Hatty mají plné ruce práce s novou výstavou v oddělení dinosaurů v
       - Descriptor 8: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:05 (MM-DD hh:mm)
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 12: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CE4 (19684)
@@ -14063,19 +14063,19 @@ Malá mláďata psounů prériových Aški a Snížek zažívají každý den sp
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:20 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CEC (19692)
@@ -14101,19 +14101,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:30 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4CF2 (19698)
@@ -14138,19 +14138,19 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 06:40 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
   - Section 73:
@@ -14225,23 +14225,23 @@ Skryté titulky"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:05 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
+        Content/type: 0xF204 (MPEG-1 Layer 2 audio, multi-lingual, multi-channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D0B (19723)
@@ -14266,19 +14266,19 @@ Zvukový popis"
       - Descriptor 4: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:15 (MM-DD hh:mm)
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D14 (19732)
@@ -14313,15 +14313,15 @@ Představte si, děťulata, že Fámula a Tryský objeví v rybníku pod ledem u
       - Descriptor 6: PDC (0x69, 105), 3 bytes
         Programme Identification Label: 01-20 07:30 (MM-DD hh:mm)
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0302 (Associated EBU Teletext)
+        Content/type: 0xF302 (Associated EBU Teletext)
         Component tag: 0x04 (4)
         Language: cze
     - Event Id: 0x4D57 (19799)
@@ -14350,15 +14350,15 @@ Určitě si taky v kině dáváte popcorn a nějakou dobrou limonádu. Jenže dr
         Language: cze
         Text: "ačí kuchyně. Uvidíte, že to není nic složitého a chutná to báječně!"
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -14384,19 +14384,19 @@ Určitě si taky v kině dáváte popcorn a nějakou dobrou limonádu. Jenže dr
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -14428,15 +14428,15 @@ Další kreslený příběh oblíbených galských hrdinů. Autoři Goscinny - U
         Language: cze
         Text: "ska Idefixe. Tentokrát, aby naši kamarádi dokázali, že jsou bohové, musí splnit dvanáct nelehkých úkolů."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -14509,15 +14509,15 @@ Další kreslený příběh oblíbených galských hrdinů. Autoři Goscinny - U
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -14542,11 +14542,11 @@ Skryté titulky"
         "Žánr" : "animovaný / loutkový"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -14577,15 +14577,15 @@ Ahoj, Šikulové, dnes vás zdravíme ze základní školy J. A. Komenského v B
         Language: cze
         Text: "e pilky, kladiva i pilníky. Ze dřeva vykouzlíme svícen, věšáček nebo přívěsek na klíče."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -14616,15 +14616,15 @@ Skryté titulky
         Language: cze
         Text: "motné matičky Země. Kdo natěží nejvíce surovin, nezabloudí v podzemí U6 a správně odpoví i na zvídavé dotazy pana Továrníka, bude mít šanci bojovat o poklad U6."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -14673,15 +14673,15 @@ Na začátku dnešního dílu se seznámíme s Benjaminem, který si přivřel p
         Language: cze
         Text: "erozumíte? No prostě: dostal takovou pětku, až si z toho zlomil ruku."
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 10: Content (0x54, 84), 2 bytes
@@ -14707,15 +14707,15 @@ Na začátku dnešního dílu se seznámíme s Benjaminem, který si přivřel p
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -14740,15 +14740,15 @@ Skryté titulky"
         Text: "4:3
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -14836,19 +14836,19 @@ Otce si zahrál Jiří Zahajský, který by v těchto dnech oslavil osm"
         Language: cze
         Text: "desáté narozeniny."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -14888,15 +14888,15 @@ Setkat se se strašidlem, to se každému hned tak nepovede. Vy teď tuto možno
         Language: cze
         Text: "ádku, ve které si zahráli A. Pyško, Z. Hadrbolcová, V. Jeníková, letošní jubilant D. Prachař, S. Stašová, S. Nálepková a O. Vízner."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Content (0x54, 84), 2 bytes
@@ -14927,15 +14927,15 @@ Naši hrdinové skákali z letadla, pátrali po ztraceném v moři, zachraňoval
         Language: cze
         Text: "u, potápěli se se žraloky, plnili všemožné, extrémně náročné disciplíny. Nyní je na čase se dozvdět, kdo z nich si vedl nejlépe. Závěrečný díl první série Hrdinů v akci. Soutěže inspirované skutečnými hrdinskými činy."
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -14970,15 +14970,15 @@ Deset úžasných dětských kuchařů čeká další dobrodružství v kuchyni 
         Language: cze
         Text: "teré proslavil sám Gordon Ramsay - proslulou hovězí svíčkovou Wellington. Dvojice kulinářských adeptů si sáhnou na dno svých sil, ale ani to nezachrání před odchodem ze soutěže další dva z nich."
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -15053,15 +15053,15 @@ Deset úžasných dětských kuchařů čeká další dobrodružství v kuchyni 
 2 jazykové verze
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15088,15 +15088,15 @@ Skryté titulky"
 2 jazykové verze
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15120,11 +15120,11 @@ Skryté titulky"
         "Žánr" : "animovaný / loutkový"
         Text: "16:9"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -15149,15 +15149,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15182,15 +15182,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15216,15 +15216,15 @@ Skryté titulky"
 2 jazykové verze
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0202 (MPEG-1 Layer 2 audio, dual mono channel)
+        Content/type: 0xF202 (MPEG-1 Layer 2 audio, dual mono channel)
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15265,19 +15265,19 @@ Hugo Mazal objeví bohatého podnikatele jménem Hilbert von Koblischek a přim�
         Language: cze
         Text: "ádkové kontrolní komise, on sám má zájem spíše o ženy než o gotické hrady a situaci rozhodně nezachrání, když Hugo omylem vypije sérum pravdy a Hilbertovi prozradí, jak to s hradem a jeho strašidly opravdu je..."
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -15302,15 +15302,15 @@ Hugo Mazal objeví bohatého podnikatele jménem Hilbert von Koblischek a přim�
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15334,11 +15334,11 @@ Skryté titulky"
         "Žánr" : "vzdělávací pořad pro děti"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -15363,11 +15363,11 @@ Skryté titulky"
         "Žánr" : "animovaný / loutkový"
         Text: "4:3"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -15392,15 +15392,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15473,15 +15473,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15507,15 +15507,15 @@ Skryté titulky"
         Text: "HDTV
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Content (0x54, 84), 2 bytes
@@ -15540,11 +15540,11 @@ Skryté titulky"
         "Žánr" : "animovaný / loutkový"
         Text: "HDTV"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Content (0x54, 84), 2 bytes
@@ -15571,19 +15571,19 @@ Skryté titulky"
 Zvukový popis
 Skryté titulky"
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0240 (MPEG-1 Layer 2 audio description for the visually impaired)
+        Content/type: 0xF240 (MPEG-1 Layer 2 audio description for the visually impaired)
         Component tag: 0x07 (7)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -15617,15 +15617,15 @@ Skryté titulky
         Language: cze
         Text: "itron, která v posledních ročnících získává na popularitě. O hudební doprovod se postará Vladimír Merta a Jitka Šuranská. Slavnostním večerem nás provede Martin Myšička."
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 7: Content (0x54, 84), 2 bytes
@@ -15670,15 +15670,15 @@ Pro hlavní roli si Otakar Vávra vybral výborného Karla H"
         Language: cze
         Text: "a mezinárodních filmových festivalech. Nejvyššího uznání se mu dostalo v San Sebastiánu, kde získal v roce 1965 kromě Velké ceny Zlaté mušle ještě dvě další ocenění - Cenu FIPRESCI a Cenu CIDALC."
       - Descriptor 6: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 7: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 8: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 9: Content (0x54, 84), 2 bytes
@@ -15760,11 +15760,11 @@ Svátek pro milovníky špičkových bigbandů připravil festival Prague Proms 
         Language: cze
         Text: " Grammy, včetně té za hudební aranže písně The Incredits z filmu Úžasňákovi. Je také držitelem tří cen Emmy."
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 6: Content (0x54, 84), 2 bytes
@@ -15822,15 +15822,15 @@ Divadelní fond českokrumlovské zámecké scény zahrnuje kromě vlastní budo
         Language: cze
         Text: "rálovském paláci v Drottningholmu."
       - Descriptor 9: Component (0x50, 80), 6 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: cze
       - Descriptor 10: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: cze
       - Descriptor 11: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x04 (4)
         Language: cze
       - Descriptor 12: Content (0x54, 84), 2 bytes

--- a/reference/test-045/test-045.tables.1.txt
+++ b/reference/test-045/test-045.tables.1.txt
@@ -44,11 +44,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -84,11 +84,11 @@
       Language: ita
       Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -124,11 +124,11 @@
       Language: ita
       Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -164,11 +164,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -200,11 +200,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -231,11 +231,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -271,11 +271,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -337,11 +337,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -368,11 +368,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -417,11 +417,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -453,11 +453,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -489,11 +489,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -525,11 +525,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -567,11 +567,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -633,11 +633,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -669,11 +669,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -709,11 +709,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -745,11 +745,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -785,11 +785,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -831,11 +831,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -897,11 +897,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -933,11 +933,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -977,11 +977,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1015,11 +1015,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1090,11 +1090,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1128,11 +1128,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1200,11 +1200,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1236,11 +1236,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1272,11 +1272,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1308,11 +1308,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1344,11 +1344,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1386,11 +1386,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1430,11 +1430,11 @@
       Language: ita
       Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1487,11 +1487,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1523,11 +1523,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1554,11 +1554,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1594,11 +1594,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1660,11 +1660,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1691,11 +1691,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1740,11 +1740,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1776,11 +1776,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1812,11 +1812,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1848,11 +1848,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1888,11 +1888,11 @@
       Language: ita
       Text: "reschi. Chi trovera' la casa perfetta?"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1924,11 +1924,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1960,11 +1960,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2000,11 +2000,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2036,11 +2036,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2076,11 +2076,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2122,11 +2122,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2188,11 +2188,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2224,11 +2224,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2268,11 +2268,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2339,11 +2339,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2377,11 +2377,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2449,11 +2449,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2485,11 +2485,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2521,11 +2521,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2557,11 +2557,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2599,11 +2599,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2665,11 +2665,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2707,11 +2707,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2768,11 +2768,11 @@
       Language: ita
       Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2810,11 +2810,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2882,11 +2882,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2922,11 +2922,11 @@
       Language: ita
       Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2962,11 +2962,11 @@
       Language: ita
       Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3002,11 +3002,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3038,11 +3038,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3069,11 +3069,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3109,11 +3109,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3175,11 +3175,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3206,11 +3206,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3255,11 +3255,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3291,11 +3291,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3327,11 +3327,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3369,11 +3369,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3435,11 +3435,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3471,11 +3471,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3511,11 +3511,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3547,11 +3547,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3587,11 +3587,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3633,11 +3633,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3699,11 +3699,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3735,11 +3735,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes

--- a/reference/test-045/test-045.tables.2.txt
+++ b/reference/test-045/test-045.tables.2.txt
@@ -27,11 +27,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -67,11 +67,11 @@
       Language: ita
       Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -107,11 +107,11 @@
       Language: ita
       Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -143,11 +143,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -174,11 +174,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -214,11 +214,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -280,11 +280,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -311,11 +311,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -360,11 +360,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -396,11 +396,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -432,11 +432,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -468,11 +468,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -508,11 +508,11 @@
       Language: ita
       Text: "reschi. Chi trovera' la casa perfetta?"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -550,11 +550,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -616,11 +616,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -652,11 +652,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -692,11 +692,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -728,11 +728,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -768,11 +768,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -814,11 +814,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -880,11 +880,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -916,11 +916,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -960,11 +960,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -998,11 +998,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1108,11 +1108,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1146,11 +1146,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1218,11 +1218,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1254,11 +1254,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1290,11 +1290,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1326,11 +1326,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1368,11 +1368,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1434,11 +1434,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1476,11 +1476,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1520,11 +1520,11 @@
       Language: ita
       Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1579,11 +1579,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1651,11 +1651,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1691,11 +1691,11 @@
       Language: ita
       Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1731,11 +1731,11 @@
       Language: ita
       Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1771,11 +1771,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1807,11 +1807,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1838,11 +1838,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1878,11 +1878,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1944,11 +1944,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -1975,11 +1975,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2024,11 +2024,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2060,11 +2060,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2096,11 +2096,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2132,11 +2132,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2174,11 +2174,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2240,11 +2240,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2276,11 +2276,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2316,11 +2316,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2352,11 +2352,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2392,11 +2392,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2438,11 +2438,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2504,11 +2504,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2540,11 +2540,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2584,11 +2584,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2622,11 +2622,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2697,11 +2697,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2735,11 +2735,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2807,11 +2807,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2843,11 +2843,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2879,11 +2879,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2915,11 +2915,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2951,11 +2951,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -2993,11 +2993,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3037,11 +3037,11 @@
       Language: ita
       Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3094,11 +3094,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3130,11 +3130,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3161,11 +3161,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3201,11 +3201,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3267,11 +3267,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3298,11 +3298,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3347,11 +3347,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3383,11 +3383,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3419,11 +3419,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3455,11 +3455,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3495,11 +3495,11 @@
       Language: ita
       Text: "reschi. Chi trovera' la casa perfetta?"
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3531,11 +3531,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3567,11 +3567,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3607,11 +3607,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3643,11 +3643,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3683,11 +3683,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3729,11 +3729,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3795,11 +3795,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3831,11 +3831,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3875,11 +3875,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3946,11 +3946,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -3984,11 +3984,11 @@
     - Descriptor 2: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4056,11 +4056,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4092,11 +4092,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4128,11 +4128,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4164,11 +4164,11 @@
       Language: ita
       Text: "test"
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4206,11 +4206,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4272,11 +4272,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4314,11 +4314,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4358,11 +4358,11 @@
       Language: ita
       Text: "uttore de "I Simpson". Tradita dalla sua migliore amica, Nadine entra in crisi, ma fra buffi imprevisti e i consigli di un professore, troverΩ il modo di reagire."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4417,11 +4417,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4489,11 +4489,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4529,11 +4529,11 @@
       Language: ita
       Text: "Torneo di Tolosa - L'Italia di Ettore Messina affronta la Francia, un'altra delle squadre che si sta preparando all'appuntamento con Eurobasket. Telecronaca di Flavio Tranquillo e Davide Pessina."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4569,11 +4569,11 @@
       Language: ita
       Text: "m, Dwayne Johnson, Kurt Russell e il premio Oscar Charlize Theron. Un'affascinante dark lady seduce Dominique Toretto e lo convince a tradire i suoi amici."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4609,11 +4609,11 @@
       Language: ita
       Text: "accidentalmente in possesso di un grosso quantitativo di droga e scatena la ritorsione di un gangster sanguinario che prenderΩ in ostaggio il figlio dell'agente."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4645,11 +4645,11 @@
       Language: ita
       Text: "Speciale Nazionale: Flavio Tranquillo intervista Luigi Datome, uno sguardo profondo dentro la Nazionale che si sta preparando in vista dei prossimi Europei. In esclusiva tutte le 76 partite del torneo."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4676,11 +4676,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x9AB0 (39600)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4716,11 +4716,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4782,11 +4782,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4813,11 +4813,11 @@
       Reference service id: 0x0BB8 (3000)
       Reference event id: 0x3000 (12288)
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 3: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4862,11 +4862,11 @@
       Language: ita
       Text: "Per conoscere gli orari di programmazione, premi il tasto "PRIMAFILA" del tuo telecomando."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4898,11 +4898,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4934,11 +4934,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -4976,11 +4976,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x09 (min. 12 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5042,11 +5042,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5078,11 +5078,11 @@
       Language: ita
       Text: "S1 Ep5 Venere prende il sopravvento - Sophie di notte diventa la Venere di Milo, la drag queen piu' esagerata della citta'. Thomas invece ha solo abiti da donna e vorrebbe riappropriarsi del suo lato maschile."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5118,11 +5118,11 @@
       Language: ita
       Text: "a nucleare, una ragazza gestisce una fattoria in una zona ancora vivibile ed Ł convinta di essere l'unica superstite. Si ricrederΩ con larrivo di due sconosciuti."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5154,11 +5154,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5194,11 +5194,11 @@
       Language: ita
       Text: "."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5240,11 +5240,11 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: ITA, rating: 0x0B (min. 14 years)
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 6: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5306,11 +5306,11 @@
       Language: ita
       Text: "Prossimamente campionato italiano di serie A,Serie B e calcio internazionale."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5342,11 +5342,11 @@
       Language: ita
       Text: "6' Stagione Ep.12 - 'Mill Street Bistro' Gordon visita il Mill Street Bistro in Ohio per trasformare il locale, ma il proprietario del ristorante e' ostile e non vuole cooperare con Ramsay. Prossimo Ep. Mer 30 AGO 11:50."
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 4: Private Data Specifier (0x5F, 95), 4 bytes
@@ -5386,11 +5386,11 @@
       Language: ita
       Text: "nessere situato sulle Alpi svizzere per riportare a casa il Ceo della sua azienda, ma rimane intrappolato nella terrificante clinica del dottor Heinrich Volmer."
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0xFF (255)
       Language:    
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0xFF (255)
       Language: ita
     - Descriptor 5: Private Data Specifier (0x5F, 95), 4 bytes

--- a/reference/test-062/test-062.tstabdump.txt
+++ b/reference/test-062/test-062.tstabdump.txt
@@ -250,7 +250,7 @@
       "出演者" : "【キャスター】青井実，【サブキャスター】池田伸子，伊藤海彦，【気象キャスター】中村美公"
       Text: ""
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x01B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
+      Content/type: 0xF1B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
       Component tag: 0x00 (0)
       Language: jpn
     - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -318,7 +318,7 @@
       "出演者" : "【語り】和久田麻由子，龍田直樹，豊嶋真千子，山田孝之，水瀬いのり"
       Text: ""
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x01B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
+      Content/type: 0xF1B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
       Component tag: 0x00 (0)
       Language: jpn
     - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -437,7 +437,7 @@
       Event name: "NHKニュース7🈔🈑"
       Description: "夜7時、「一歩先へ、一歩深く」　今、このニュースを届けたい　【キャスター】青井実，【サブキャスター】池田伸子，伊藤海彦，【気象キャスター】中村美公"
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x01B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
+      Content/type: 0xF1B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
       Component tag: 0x00 (0)
       Language: jpn
     - Descriptor 2: Content (0x54, 84), 6 bytes
@@ -488,7 +488,7 @@
       Event name: "ダーウィンが来た！「波乱のライオン学園に潜入！百獣の王を養成！！」🈖🈑"
       Description: "成長まっただ中のライオンの子どもたちが、群れの中で先生役の大人から狩りの技や子育て術を学ぶ。不真面目な生徒は退学処分に！？学園ドラマ顔負けの波乱の日々に密着！"
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x01B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
+      Content/type: 0xF1B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
       Component tag: 0x00 (0)
       Language: jpn
     - Descriptor 2: Content (0x54, 84), 4 bytes

--- a/reference/test-062/test-062.tstables.text.txt
+++ b/reference/test-062/test-062.tstables.text.txt
@@ -255,7 +255,7 @@
         "出演者" : "【キャスター】青井実，【サブキャスター】池田伸子，伊藤海彦，【気象キャスター】中村美公"
         Text: ""
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x01B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
+        Content/type: 0xF1B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
         Component tag: 0x00 (0)
         Language: jpn
       - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -321,7 +321,7 @@
         "出演者" : "【語り】和久田麻由子，龍田直樹，豊嶋真千子，山田孝之，水瀬いのり"
         Text: ""
       - Descriptor 4: Component (0x50, 80), 6 bytes
-        Content/type: 0x01B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
+        Content/type: 0xF1B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
         Component tag: 0x00 (0)
         Language: jpn
       - Descriptor 5: Content (0x54, 84), 4 bytes
@@ -442,7 +442,7 @@
         Event name: "NHKニュース7🈔🈑"
         Description: "夜7時、「一歩先へ、一歩深く」　今、このニュースを届けたい　【キャスター】青井実，【サブキャスター】池田伸子，伊藤海彦，【気象キャスター】中村美公"
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x01B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
+        Content/type: 0xF1B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
         Component tag: 0x00 (0)
         Language: jpn
       - Descriptor 2: Content (0x54, 84), 6 bytes
@@ -491,7 +491,7 @@
         Event name: "ダーウィンが来た！「波乱のライオン学園に潜入！百獣の王を養成！！」🈖🈑"
         Description: "成長まっただ中のライオンの子どもたちが、群れの中で先生役の大人から狩りの技や子育て術を学ぶ。不真面目な生徒は退学処分に！？学園ドラマ顔負けの波乱の日々に密着！"
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x01B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
+        Content/type: 0xF1B3 (Video 1080i(1125i), 16:9 aspect ratio, without pan vectors)
         Component tag: 0x00 (0)
         Language: jpn
       - Descriptor 2: Content (0x54, 84), 4 bytes

--- a/reference/test-092/test-092.tstabdump.txt
+++ b/reference/test-092/test-092.tstabdump.txt
@@ -262,17 +262,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 19 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -302,17 +302,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 19 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -342,17 +342,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 19 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -382,17 +382,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 19 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -422,12 +422,12 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 17 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -456,12 +456,12 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 17 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -490,17 +490,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 19 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -530,17 +530,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 19 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -570,17 +570,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 19 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -610,17 +610,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 19 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -650,12 +650,12 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -685,12 +685,12 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -937,12 +937,12 @@
       Content: 0x12 (adventure/western/war) / User: 0x00
       Content: 0x10 (movie/drama (general)) / User: 0x00
     - Descriptor 4: Component (0x50, 80), 43 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 5: Component (0x50, 80), 24 bytes
-      Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+      Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
       Component tag: 0x02 (2)
       Language: fre
       Description: "multi-channel 5.1"
@@ -977,12 +977,12 @@
       Content: 0x12 (adventure/western/war) / User: 0x00
       Content: 0x10 (movie/drama (general)) / User: 0x00
     - Descriptor 5: Component (0x50, 80), 43 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 6: Component (0x50, 80), 24 bytes
-      Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+      Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
       Component tag: 0x02 (2)
       Language: fre
       Description: "multi-channel 5.1"
@@ -1012,17 +1012,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 43 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 5: Component (0x50, 80), 87 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
     - Descriptor 6: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
@@ -1052,17 +1052,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 43 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 5: Component (0x50, 80), 87 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
     - Descriptor 6: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
@@ -1084,11 +1084,11 @@
       Event name: "Au coeur de la course"
       Description: ""
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -1115,11 +1115,11 @@
       Event name: "Journal"
       Description: ""
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -1146,15 +1146,15 @@
       Event name: "The Foreigner"
       Description: "Réalisé par Martin Campbell en 2017. Avec Jackie Chan, Pierce Brosnan, Charlie Murphy. Thriller britannico-chinois."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0444 (AC-3, full, complete main, multichannel > 2)
+      Content/type: 0xF444 (AC-3, full, complete main, multichannel > 2)
       Component tag: 0x03 (3)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0444 (AC-3, full, complete main, multichannel > 2)
+      Content/type: 0xF444 (AC-3, full, complete main, multichannel > 2)
       Component tag: 0x03 (3)
       Language: eng
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1162,7 +1162,7 @@
       Content: 0xBF (unknown) / User: 0x01
       Content: 0xBF (unknown) / User: 0x11
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x0C (12)
       Language: fre
     - Descriptor 6: Parental Rating (0x55, 85), 4 bytes
@@ -1185,11 +1185,11 @@
       Event name: "L'hebd'Hollywood"
       Description: "Présenté par Didier Allouch. Toute l'actualité d'Hollywood, des stars et des derniers films à ne pas manquer."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 4 bytes
@@ -1259,15 +1259,15 @@ REDIFFUSION : le 24 Jan à 00:00"
       Event name: "Body of Proof"
       Description: "Série policière américaine avec Dana Delany, Mary Mouser, Jeri Ryan. Saison 1. (4/9). "Puzzle macabre"."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1275,7 +1275,7 @@ REDIFFUSION : le 24 Jan à 00:00"
       Content: 0xBF (unknown) / User: 0x01
       Content: 0xBF (unknown) / User: 0x11
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x0C (12)
       Language: fre
     - Descriptor 6: Extended Event (0x4E, 78), 23 bytes
@@ -1303,15 +1303,15 @@ Episode : 4 / 9"
       Event name: "Body of Proof"
       Description: "Série policière américaine avec Dana Delany, Jeri Ryan, Jay Karnes. Saison 2. (2/20). "Partie de chasse"."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1319,7 +1319,7 @@ Episode : 4 / 9"
       Content: 0xBF (unknown) / User: 0x01
       Content: 0xBF (unknown) / User: 0x11
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x0C (12)
       Language: fre
     - Descriptor 6: Extended Event (0x4E, 78), 24 bytes
@@ -1355,12 +1355,12 @@ Episode : 2 / 20"
     - Descriptor 3: Content (0x54, 84), 2 bytes
       Content: 0x10 (movie/drama (general)) / User: 0x00
     - Descriptor 4: Component (0x50, 80), 43 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 5: Component (0x50, 80), 24 bytes
-      Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+      Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
       Component tag: 0x02 (2)
       Language: fre
       Description: "multi-channel 5.1"
@@ -1395,22 +1395,22 @@ Episode : 2 / 20"
       Content: 0x10 (movie/drama (general)) / User: 0x00
       Content: 0x12 (adventure/western/war) / User: 0x00
     - Descriptor 5: Component (0x50, 80), 43 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 6: Component (0x50, 80), 24 bytes
-      Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+      Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
       Component tag: 0x02 (2)
       Language: fre
       Description: "multi-channel 5.1"
     - Descriptor 7: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x04 (4)
       Language: qaa
       Description: "stereo"
     - Descriptor 8: Component (0x50, 80), 87 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
@@ -1440,12 +1440,12 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -1475,12 +1475,12 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 14 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -1554,32 +1554,32 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 4: Content (0x54, 84), 2 bytes
       Content: 0x10 (movie/drama (general)) / User: 0x00
     - Descriptor 5: Component (0x50, 80), 43 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 6: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
     - Descriptor 7: Component (0x50, 80), 13 bytes
-      Content/type: 0x04D2 (Enhanced AC-3, full, visually impaired, 2 channels)
+      Content/type: 0xF4D2 (Enhanced AC-3, full, visually impaired, 2 channels)
       Component tag: 0x03 (3)
       Language: qad
       Description: "stereo"
     - Descriptor 8: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x07 (7)
       Language: deu
       Description: "stereo"
     - Descriptor 9: Component (0x50, 80), 41 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Sous-titrage malentendant français"
     - Descriptor 10: Component (0x50, 80), 36 bytes
-      Content/type: 0x0314 (DVB subtitles, high definition)
+      Content/type: 0xF314 (DVB subtitles, high definition)
       Component tag: 0x08 (8)
       Language: deu
       Description: "Sous-titrage partiel allemand"
@@ -1615,27 +1615,27 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 4: Content (0x54, 84), 2 bytes
       Content: 0x82 (economics/social advisory) / User: 0x00
     - Descriptor 5: Component (0x50, 80), 43 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 6: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
     - Descriptor 7: Component (0x50, 80), 13 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x07 (7)
       Language: deu
       Description: "stereo"
     - Descriptor 8: Component (0x50, 80), 41 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Sous-titrage malentendant français"
     - Descriptor 9: Component (0x50, 80), 36 bytes
-      Content/type: 0x0314 (DVB subtitles, high definition)
+      Content/type: 0xF314 (DVB subtitles, high definition)
       Component tag: 0x08 (8)
       Language: deu
       Description: "Sous-titrage partiel allemand"

--- a/reference/test-092/test-092.tstables.text.txt
+++ b/reference/test-092/test-092.tstables.text.txt
@@ -272,17 +272,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
       - Descriptor 6: Component (0x50, 80), 19 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Malentendant"
@@ -310,17 +310,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
       - Descriptor 6: Component (0x50, 80), 19 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Malentendant"
@@ -351,17 +351,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
       - Descriptor 6: Component (0x50, 80), 19 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Malentendant"
@@ -389,17 +389,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
       - Descriptor 6: Component (0x50, 80), 19 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Malentendant"
@@ -430,12 +430,12 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 17 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: fre
         Description: "AudioTrack"
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
   - Section 1:
@@ -462,12 +462,12 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 17 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x02 (2)
         Language: fre
         Description: "AudioTrack"
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
 
@@ -497,17 +497,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
       - Descriptor 6: Component (0x50, 80), 19 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Malentendant"
@@ -535,17 +535,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
       - Descriptor 6: Component (0x50, 80), 19 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Malentendant"
@@ -576,17 +576,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
       - Descriptor 6: Component (0x50, 80), 19 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Malentendant"
@@ -614,17 +614,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
       - Descriptor 6: Component (0x50, 80), 19 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Malentendant"
@@ -655,12 +655,12 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
@@ -688,12 +688,12 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
@@ -942,12 +942,12 @@
         Content: 0x12 (adventure/western/war) / User: 0x00
         Content: 0x10 (movie/drama (general)) / User: 0x00
       - Descriptor 4: Component (0x50, 80), 43 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "video, 16:9 without pan vector, 25Hz"
       - Descriptor 5: Component (0x50, 80), 24 bytes
-        Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+        Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
         Component tag: 0x02 (2)
         Language: fre
         Description: "multi-channel 5.1"
@@ -980,12 +980,12 @@
         Content: 0x12 (adventure/western/war) / User: 0x00
         Content: 0x10 (movie/drama (general)) / User: 0x00
       - Descriptor 5: Component (0x50, 80), 43 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "video, 16:9 without pan vector, 25Hz"
       - Descriptor 6: Component (0x50, 80), 24 bytes
-        Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+        Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
         Component tag: 0x02 (2)
         Language: fre
         Description: "multi-channel 5.1"
@@ -1016,17 +1016,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 43 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "video, 16:9 without pan vector, 25Hz"
       - Descriptor 5: Component (0x50, 80), 87 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
       - Descriptor 6: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "stereo"
@@ -1054,17 +1054,17 @@
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 43 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "video, 16:9 without pan vector, 25Hz"
       - Descriptor 5: Component (0x50, 80), 87 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
       - Descriptor 6: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "stereo"
@@ -1087,11 +1087,11 @@
         Event name: "Au coeur de la course"
         Description: ""
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x05 (5)
         Language: fre
       - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -1116,11 +1116,11 @@
         Event name: "Journal"
         Description: ""
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x05 (5)
         Language: fre
       - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -1148,15 +1148,15 @@
         Event name: "The Foreigner"
         Description: "Réalisé par Martin Campbell en 2017. Avec Jackie Chan, Pierce Brosnan, Charlie Murphy. Thriller britannico-chinois."
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x0444 (AC-3, full, complete main, multichannel > 2)
+        Content/type: 0xF444 (AC-3, full, complete main, multichannel > 2)
         Component tag: 0x03 (3)
         Language: fre
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0444 (AC-3, full, complete main, multichannel > 2)
+        Content/type: 0xF444 (AC-3, full, complete main, multichannel > 2)
         Component tag: 0x03 (3)
         Language: eng
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x05 (5)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1164,7 +1164,7 @@
         Content: 0xBF (unknown) / User: 0x01
         Content: 0xBF (unknown) / User: 0x11
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x0C (12)
         Language: fre
       - Descriptor 6: Parental Rating (0x55, 85), 4 bytes
@@ -1185,11 +1185,11 @@
         Event name: "L'hebd'Hollywood"
         Description: "Présenté par Didier Allouch. Toute l'actualité d'Hollywood, des stars et des derniers films à ne pas manquer."
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+        Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
         Component tag: 0x05 (5)
         Language: fre
       - Descriptor 3: Content (0x54, 84), 4 bytes
@@ -1259,15 +1259,15 @@ REDIFFUSION : le 24 Jan à 00:00"
         Event name: "Body of Proof"
         Description: "Série policière américaine avec Dana Delany, Mary Mouser, Jeri Ryan. Saison 1. (4/9). "Puzzle macabre"."
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x05 (5)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1275,7 +1275,7 @@ REDIFFUSION : le 24 Jan à 00:00"
         Content: 0xBF (unknown) / User: 0x01
         Content: 0xBF (unknown) / User: 0x11
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x0C (12)
         Language: fre
       - Descriptor 6: Extended Event (0x4E, 78), 23 bytes
@@ -1301,15 +1301,15 @@ Episode : 4 / 9"
         Event name: "Body of Proof"
         Description: "Série policière américaine avec Dana Delany, Jeri Ryan, Jay Karnes. Saison 2. (2/20). "Partie de chasse"."
       - Descriptor 1: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: fre
       - Descriptor 2: Component (0x50, 80), 6 bytes
-        Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+        Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
         Component tag: 0x01 (1)
         Language: eng
       - Descriptor 3: Component (0x50, 80), 6 bytes
-        Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+        Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
         Component tag: 0x05 (5)
         Language: fre
       - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -1317,7 +1317,7 @@ Episode : 4 / 9"
         Content: 0xBF (unknown) / User: 0x01
         Content: 0xBF (unknown) / User: 0x11
       - Descriptor 5: Component (0x50, 80), 6 bytes
-        Content/type: 0x0301 (EBU Teletext subtitles)
+        Content/type: 0xF301 (EBU Teletext subtitles)
         Component tag: 0x0C (12)
         Language: fre
       - Descriptor 6: Extended Event (0x4E, 78), 24 bytes
@@ -1354,12 +1354,12 @@ Episode : 2 / 20"
       - Descriptor 3: Content (0x54, 84), 2 bytes
         Content: 0x10 (movie/drama (general)) / User: 0x00
       - Descriptor 4: Component (0x50, 80), 43 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "video, 16:9 without pan vector, 25Hz"
       - Descriptor 5: Component (0x50, 80), 24 bytes
-        Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+        Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
         Component tag: 0x02 (2)
         Language: fre
         Description: "multi-channel 5.1"
@@ -1392,22 +1392,22 @@ Episode : 2 / 20"
         Content: 0x10 (movie/drama (general)) / User: 0x00
         Content: 0x12 (adventure/western/war) / User: 0x00
       - Descriptor 5: Component (0x50, 80), 43 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "video, 16:9 without pan vector, 25Hz"
       - Descriptor 6: Component (0x50, 80), 24 bytes
-        Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+        Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
         Component tag: 0x02 (2)
         Language: fre
         Description: "multi-channel 5.1"
       - Descriptor 7: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x04 (4)
         Language: qaa
         Description: "stereo"
       - Descriptor 8: Component (0x50, 80), 87 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
@@ -1438,12 +1438,12 @@ Episode : 2 / 20"
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
@@ -1471,12 +1471,12 @@ Episode : 2 / 20"
       - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
         Country code: fra, rating: 0x00 (undefined)
       - Descriptor 4: Component (0x50, 80), 14 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "MPEG4HD"
       - Descriptor 5: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "DD+ VF"
@@ -1550,32 +1550,32 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
       - Descriptor 4: Content (0x54, 84), 2 bytes
         Content: 0x10 (movie/drama (general)) / User: 0x00
       - Descriptor 5: Component (0x50, 80), 43 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "video, 16:9 without pan vector, 25Hz"
       - Descriptor 6: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "stereo"
       - Descriptor 7: Component (0x50, 80), 13 bytes
-        Content/type: 0x04D2 (Enhanced AC-3, full, visually impaired, 2 channels)
+        Content/type: 0xF4D2 (Enhanced AC-3, full, visually impaired, 2 channels)
         Component tag: 0x03 (3)
         Language: qad
         Description: "stereo"
       - Descriptor 8: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x07 (7)
         Language: deu
         Description: "stereo"
       - Descriptor 9: Component (0x50, 80), 41 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Sous-titrage malentendant français"
       - Descriptor 10: Component (0x50, 80), 36 bytes
-        Content/type: 0x0314 (DVB subtitles, high definition)
+        Content/type: 0xF314 (DVB subtitles, high definition)
         Component tag: 0x08 (8)
         Language: deu
         Description: "Sous-titrage partiel allemand"
@@ -1609,27 +1609,27 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
       - Descriptor 4: Content (0x54, 84), 2 bytes
         Content: 0x82 (economics/social advisory) / User: 0x00
       - Descriptor 5: Component (0x50, 80), 43 bytes
-        Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+        Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
         Component tag: 0x01 (1)
         Language: fre
         Description: "video, 16:9 without pan vector, 25Hz"
       - Descriptor 6: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x02 (2)
         Language: fre
         Description: "stereo"
       - Descriptor 7: Component (0x50, 80), 13 bytes
-        Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+        Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
         Component tag: 0x07 (7)
         Language: deu
         Description: "stereo"
       - Descriptor 8: Component (0x50, 80), 41 bytes
-        Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+        Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
         Component tag: 0x05 (5)
         Language: fre
         Description: "Sous-titrage malentendant français"
       - Descriptor 9: Component (0x50, 80), 36 bytes
-        Content/type: 0x0314 (DVB subtitles, high definition)
+        Content/type: 0xF314 (DVB subtitles, high definition)
         Component tag: 0x08 (8)
         Language: deu
         Description: "Sous-titrage partiel allemand"

--- a/reference/test-124/test-124.eit.out.txt
+++ b/reference/test-124/test-124.eit.out.txt
@@ -24,17 +24,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -69,12 +69,12 @@
       Content: 0x12 (adventure/western/war) / User: 0x00
       Content: 0x10 (movie/drama (general)) / User: 0x00
     - Descriptor 5: Component (0x50, 80), 42 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 6: Component (0x50, 80), 23 bytes
-      Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+      Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
       Component tag: 0x02 (2)
       Language: fre
       Description: "multi-channel 5.1"
@@ -104,17 +104,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -144,17 +144,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -176,17 +176,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -208,17 +208,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -240,17 +240,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -272,17 +272,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -304,17 +304,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -336,17 +336,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -368,17 +368,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -400,17 +400,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -440,12 +440,12 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -474,12 +474,12 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -508,17 +508,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 42 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 5: Component (0x50, 80), 86 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
     - Descriptor 6: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
@@ -540,11 +540,11 @@
       Event name: "Journal"
       Description: ""
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -579,17 +579,17 @@
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -611,11 +611,11 @@
       Event name: "L'hebd'Hollywood"
       Description: "Présenté par Didier Allouch. Toute l'actualité d'Hollywood, des stars et des derniers films à ne pas manquer."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 4 bytes
@@ -655,17 +655,17 @@ REDIFFUSION : le 24 Jan à 00:00"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -695,17 +695,17 @@ REDIFFUSION : le 24 Jan à 00:00"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -727,17 +727,17 @@ REDIFFUSION : le 24 Jan à 00:00"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -759,17 +759,17 @@ REDIFFUSION : le 24 Jan à 00:00"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -791,17 +791,17 @@ REDIFFUSION : le 24 Jan à 00:00"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -823,17 +823,17 @@ REDIFFUSION : le 24 Jan à 00:00"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -882,12 +882,12 @@ REDIFFUSION : le 24 Jan à 00:00"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -909,15 +909,15 @@ REDIFFUSION : le 24 Jan à 00:00"
       Event name: "Body of Proof"
       Description: "Série policière américaine avec Dana Delany, Mary Mouser, Jeri Ryan. Saison 1. (4/9). "Puzzle macabre"."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -925,7 +925,7 @@ REDIFFUSION : le 24 Jan à 00:00"
       Content: 0xBF (unknown) / User: 0x01
       Content: 0xBF (unknown) / User: 0x11
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x0C (12)
       Language: fre
     - Descriptor 6: Extended Event (0x4E, 78), 22 bytes
@@ -961,17 +961,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -993,17 +993,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1025,17 +1025,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1057,17 +1057,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1097,17 +1097,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1137,12 +1137,12 @@ Episode : 4 / 9"
     - Descriptor 3: Content (0x54, 84), 2 bytes
       Content: 0x10 (movie/drama (general)) / User: 0x00
     - Descriptor 4: Component (0x50, 80), 42 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 5: Component (0x50, 80), 23 bytes
-      Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+      Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
       Component tag: 0x02 (2)
       Language: fre
       Description: "multi-channel 5.1"
@@ -1172,12 +1172,12 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -1199,12 +1199,12 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -1234,17 +1234,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1274,12 +1274,12 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -1309,12 +1309,12 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -1362,17 +1362,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1402,17 +1402,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1434,17 +1434,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1466,17 +1466,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1498,17 +1498,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1530,17 +1530,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1562,17 +1562,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1602,17 +1602,17 @@ Episode : 4 / 9"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1648,32 +1648,32 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 4: Content (0x54, 84), 2 bytes
       Content: 0x10 (movie/drama (general)) / User: 0x00
     - Descriptor 5: Component (0x50, 80), 42 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 6: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
     - Descriptor 7: Component (0x50, 80), 12 bytes
-      Content/type: 0x04D2 (Enhanced AC-3, full, visually impaired, 2 channels)
+      Content/type: 0xF4D2 (Enhanced AC-3, full, visually impaired, 2 channels)
       Component tag: 0x03 (3)
       Language: qad
       Description: "stereo"
     - Descriptor 8: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x07 (7)
       Language: deu
       Description: "stereo"
     - Descriptor 9: Component (0x50, 80), 41 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Sous-titrage malentendant français"
     - Descriptor 10: Component (0x50, 80), 35 bytes
-      Content/type: 0x0314 (DVB subtitles, high definition)
+      Content/type: 0xF314 (DVB subtitles, high definition)
       Component tag: 0x08 (8)
       Language: deu
       Description: "Sous-titrage partiel allemand"
@@ -1703,12 +1703,12 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -1738,12 +1738,12 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -1772,17 +1772,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1812,12 +1812,12 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -1847,17 +1847,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -1887,12 +1887,12 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -1922,12 +1922,12 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -1950,17 +1950,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 1: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 2: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
     - Descriptor 3: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
     - Descriptor 4: Component (0x50, 80), 42 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
@@ -1990,17 +1990,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2030,17 +2030,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2062,17 +2062,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2094,17 +2094,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2126,17 +2126,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2158,17 +2158,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2190,17 +2190,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2222,17 +2222,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2254,17 +2254,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2286,17 +2286,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2318,17 +2318,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2350,17 +2350,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2382,17 +2382,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2414,17 +2414,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2473,17 +2473,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2513,12 +2513,12 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -2547,12 +2547,12 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -2601,17 +2601,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2664,17 +2664,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2696,17 +2696,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2728,17 +2728,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2760,17 +2760,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2792,17 +2792,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2824,17 +2824,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2856,17 +2856,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2888,17 +2888,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2928,17 +2928,17 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -2960,11 +2960,11 @@ Sous-titres pour sourds et malentendants disponibles pour ce programme"
       Event name: "Rallye - Championnat du monde 2019"
       Description: "Championnat du monde 2019. Présentation de la saison."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 4 bytes
@@ -3003,12 +3003,12 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -3025,7 +3025,7 @@ REDIFFUSION : le 22 Jan à 23:50"
     Running status: running
     CA mode: free
     - Descriptor 0: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
@@ -3042,11 +3042,11 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 4: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x07 (min. 10 years)
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF103 (MPEG-2 video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 6: Component (0x50, 80), 86 bytes
-      Content/type: 0x0322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
+      Content/type: 0xF322 (DVB subtitles for hard of hearing, 16:9 aspect ratio)
       Component tag: 0x05 (5)
       Language: fre
       Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
@@ -3076,17 +3076,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3108,17 +3108,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3140,17 +3140,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3172,17 +3172,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3204,12 +3204,12 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -3231,17 +3231,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3263,17 +3263,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3303,17 +3303,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3335,11 +3335,11 @@ REDIFFUSION : le 22 Jan à 23:50"
       Event name: "The Tonight Show Starring Jimmy Fallon"
       Description: "The Tonight Show Starring Jimmy Fallon Talk-show. Présenté par Jimmy Fallon."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: eng
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -3347,7 +3347,7 @@ REDIFFUSION : le 22 Jan à 23:50"
       Content: 0xB0 (original language) / User: 0x10
       Content: 0xBF (unknown) / User: 0x11
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x0C (12)
       Language: fre
     - Descriptor 5: Parental Rating (0x55, 85), 4 bytes
@@ -3378,17 +3378,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3418,12 +3418,12 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -3445,12 +3445,12 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -3472,12 +3472,12 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -3507,12 +3507,12 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -3542,12 +3542,12 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -3577,17 +3577,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3617,17 +3617,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3649,17 +3649,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3681,17 +3681,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3713,17 +3713,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3753,17 +3753,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3791,12 +3791,12 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 2: Content (0x54, 84), 2 bytes
       Content: 0xFF (unknown) / User: 0x6B
     - Descriptor 3: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 4: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -3828,17 +3828,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3868,17 +3868,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3900,17 +3900,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3932,17 +3932,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -3972,12 +3972,12 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -4010,17 +4010,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 4: Content (0x54, 84), 2 bytes
       Content: 0x11 (detective/thriller) / User: 0x00
     - Descriptor 5: Component (0x50, 80), 42 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 6: Component (0x50, 80), 23 bytes
-      Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+      Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
       Component tag: 0x02 (2)
       Language: fre
       Description: "multi-channel 5.1"
     - Descriptor 7: Component (0x50, 80), 86 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
@@ -4050,17 +4050,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4090,17 +4090,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4122,17 +4122,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x07 (min. 10 years)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4154,17 +4154,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x07 (min. 10 years)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4194,17 +4194,17 @@ REDIFFUSION : le 22 Jan à 23:50"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4226,11 +4226,11 @@ REDIFFUSION : le 22 Jan à 23:50"
       Event name: "Le choc des continents"
       Description: "Documentaire britannique réalisé par Arif Nurmohamed, Helen Quinn en 2013 (3/4). "L'Amérique"."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 4 bytes
@@ -4270,12 +4270,12 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -4306,12 +4306,12 @@ REDIFFUSION : le 28 Jan à 14:20"
       Content: 0x12 (adventure/western/war) / User: 0x00
       Content: 0x10 (movie/drama (general)) / User: 0x00
     - Descriptor 4: Component (0x50, 80), 42 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 5: Component (0x50, 80), 23 bytes
-      Content/type: 0x04C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
+      Content/type: 0xF4C5 (Enhanced AC-3, full, complete main, multichannel > 5.1)
       Component tag: 0x02 (2)
       Language: fre
       Description: "multi-channel 5.1"
@@ -4341,17 +4341,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4381,17 +4381,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 42 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "video, 16:9 without pan vector, 25Hz"
     - Descriptor 5: Component (0x50, 80), 86 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor"
     - Descriptor 6: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "stereo"
@@ -4421,17 +4421,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4453,11 +4453,11 @@ REDIFFUSION : le 28 Jan à 14:20"
       Event name: "Au coeur de la course"
       Description: ""
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -4492,12 +4492,12 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 
@@ -4518,15 +4518,15 @@ REDIFFUSION : le 28 Jan à 14:20"
       Event name: "The Foreigner"
       Description: "Réalisé par Martin Campbell en 2017. Avec Jackie Chan, Pierce Brosnan, Charlie Murphy. Thriller britannico-chinois."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0444 (AC-3, full, complete main, multichannel > 2)
+      Content/type: 0xF444 (AC-3, full, complete main, multichannel > 2)
       Component tag: 0x03 (3)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0444 (AC-3, full, complete main, multichannel > 2)
+      Content/type: 0xF444 (AC-3, full, complete main, multichannel > 2)
       Component tag: 0x03 (3)
       Language: eng
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -4534,7 +4534,7 @@ REDIFFUSION : le 28 Jan à 14:20"
       Content: 0xBF (unknown) / User: 0x01
       Content: 0xBF (unknown) / User: 0x11
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x0C (12)
       Language: fre
     - Descriptor 6: Parental Rating (0x55, 85), 4 bytes
@@ -4565,17 +4565,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4597,17 +4597,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4629,17 +4629,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4661,17 +4661,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4693,17 +4693,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4725,22 +4725,22 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 26 bytes
-      Content/type: 0x04D2 (Enhanced AC-3, full, visually impaired, 2 channels)
+      Content/type: 0xF4D2 (Enhanced AC-3, full, visually impaired, 2 channels)
       Component tag: 0x03 (3)
       Language: fre
       Description: "DD+ Audiodescription"
     - Descriptor 7: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4762,22 +4762,22 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 26 bytes
-      Content/type: 0x04D2 (Enhanced AC-3, full, visually impaired, 2 channels)
+      Content/type: 0xF4D2 (Enhanced AC-3, full, visually impaired, 2 channels)
       Component tag: 0x03 (3)
       Language: fre
       Description: "DD+ Audiodescription"
     - Descriptor 7: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4799,22 +4799,22 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 26 bytes
-      Content/type: 0x04D2 (Enhanced AC-3, full, visually impaired, 2 channels)
+      Content/type: 0xF4D2 (Enhanced AC-3, full, visually impaired, 2 channels)
       Component tag: 0x03 (3)
       Language: fre
       Description: "DD+ Audiodescription"
     - Descriptor 7: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4836,17 +4836,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4868,27 +4868,27 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x07 (min. 10 years)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x04 (4)
       Language: fre
       Description: "DD+ VO"
     - Descriptor 7: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
     - Descriptor 8: Component (0x50, 80), 17 bytes
-      Content/type: 0x0314 (DVB subtitles, high definition)
+      Content/type: 0xF314 (DVB subtitles, high definition)
       Component tag: 0x06 (6)
       Language: fre
       Description: "Multilingue"
@@ -4918,17 +4918,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -4977,17 +4977,17 @@ REDIFFUSION : le 28 Jan à 14:20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5009,15 +5009,15 @@ REDIFFUSION : le 28 Jan à 14:20"
       Event name: "Body of Proof"
       Description: "Série policière américaine avec Dana Delany, Jeri Ryan, Jay Karnes. Saison 2. (2/20). "Partie de chasse"."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: eng
     - Descriptor 3: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 4: Content (0x54, 84), 6 bytes
@@ -5025,7 +5025,7 @@ REDIFFUSION : le 28 Jan à 14:20"
       Content: 0xBF (unknown) / User: 0x01
       Content: 0xBF (unknown) / User: 0x11
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x0C (12)
       Language: fre
     - Descriptor 6: Extended Event (0x4E, 78), 23 bytes
@@ -5061,12 +5061,12 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -5096,17 +5096,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5128,17 +5128,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5160,17 +5160,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5192,17 +5192,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5224,17 +5224,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5256,17 +5256,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5288,17 +5288,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5320,17 +5320,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5352,17 +5352,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5384,17 +5384,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5424,17 +5424,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5464,17 +5464,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5504,12 +5504,12 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x04C2 (Enhanced AC-3, full, complete main, 2 channels)
+      Content/type: 0xF4C2 (Enhanced AC-3, full, complete main, 2 channels)
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
@@ -5539,17 +5539,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5571,17 +5571,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5603,17 +5603,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5635,17 +5635,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5667,17 +5667,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5699,17 +5699,17 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 13 bytes
-      Content/type: 0x050B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
+      Content/type: 0xF50B (H.264/AVC high definition video, 16:9 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
       Description: "MPEG4HD"
     - Descriptor 5: Component (0x50, 80), 12 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "DD+ VF"
     - Descriptor 6: Component (0x50, 80), 18 bytes
-      Content/type: 0x0324 (DVB subtitles for hard of hearing, high definition)
+      Content/type: 0xF324 (DVB subtitles for hard of hearing, high definition)
       Component tag: 0x05 (5)
       Language: fre
       Description: "Malentendant"
@@ -5739,12 +5739,12 @@ Episode : 2 / 20"
     - Descriptor 3: Parental Rating (0x55, 85), 4 bytes
       Country code: fra, rating: 0x00 (undefined)
     - Descriptor 4: Component (0x50, 80), 16 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: fre
       Description: "AudioTrack"
     - Descriptor 5: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x01 (1)
       Language: fre
 

--- a/reference/test-126/test-126.tables.2.txt
+++ b/reference/test-126/test-126.tables.2.txt
@@ -16,11 +16,11 @@
       Event name: "Journal"
       Description: ""
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -47,11 +47,11 @@
       Event name: "L'hebd'Hollywood"
       Description: "Présenté par Didier Allouch. Toute l'actualité d'Hollywood, des stars et des derniers films à ne pas manquer."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 4 bytes
@@ -83,11 +83,11 @@ REDIFFUSION : le 24 Jan à 00:00"
       Event name: "Rallye - Championnat du monde 2019"
       Description: "Championnat du monde 2019. Présentation de la saison."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 4 bytes
@@ -118,11 +118,11 @@ REDIFFUSION : le 22 Jan à 23:50"
       Event name: "The Tonight Show Starring Jimmy Fallon"
       Description: "The Tonight Show Starring Jimmy Fallon Talk-show. Présenté par Jimmy Fallon."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x02 (2)
       Language: eng
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 6 bytes
@@ -130,7 +130,7 @@ REDIFFUSION : le 22 Jan à 23:50"
       Content: 0xB0 (original language) / User: 0x10
       Content: 0xBF (unknown) / User: 0x11
     - Descriptor 4: Component (0x50, 80), 6 bytes
-      Content/type: 0x0301 (EBU Teletext subtitles)
+      Content/type: 0xF301 (EBU Teletext subtitles)
       Component tag: 0x0C (12)
       Language: fre
     - Descriptor 5: Parental Rating (0x55, 85), 4 bytes
@@ -153,11 +153,11 @@ REDIFFUSION : le 22 Jan à 23:50"
       Event name: "Le choc des continents"
       Description: "Documentaire britannique réalisé par Arif Nurmohamed, Helen Quinn en 2013 (3/4). "L'Amérique"."
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x010B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
+      Content/type: 0xF10B (MPEG-2 high definition video, 16:9 aspect ratio without pan vectors, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 4 bytes
@@ -189,11 +189,11 @@ REDIFFUSION : le 28 Jan à 14:20"
       Event name: "Au coeur de la course"
       Description: ""
     - Descriptor 1: Component (0x50, 80), 6 bytes
-      Content/type: 0x0203 (MPEG-1 Layer 2 audio, stereo (2 channel))
+      Content/type: 0xF203 (MPEG-1 Layer 2 audio, stereo (2 channel))
       Component tag: 0x01 (1)
       Language: fre
     - Descriptor 2: Component (0x50, 80), 6 bytes
-      Content/type: 0x0101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
+      Content/type: 0xF101 (MPEG-2 video, 4:3 aspect ratio, 25 Hz)
       Component tag: 0x05 (5)
       Language: fre
     - Descriptor 3: Content (0x54, 84), 6 bytes

--- a/reference/test-170/test-170.tstabdump.txt
+++ b/reference/test-170/test-170.tstabdump.txt
@@ -145,7 +145,7 @@
       Language code: "por"
       Text: "Est?reo"
     - Descriptor 3: Component (0x50, 80), 7 bytes
-      Content/type: 0x05B2 (H.264/AVC)
+      Content/type: 0xF5B2 (H.264/AVC)
       Component tag: 0x00 (0)
       Language: por
       Description: " "
@@ -194,7 +194,7 @@
       Language code: "por"
       Text: "Est?reo"
     - Descriptor 3: Component (0x50, 80), 7 bytes
-      Content/type: 0x05B2 (H.264/AVC)
+      Content/type: 0xF5B2 (H.264/AVC)
       Component tag: 0x00 (0)
       Language: por
       Description: " "

--- a/reference/test-170/test-170.tstables.text.txt
+++ b/reference/test-170/test-170.tstables.text.txt
@@ -152,7 +152,7 @@
         Language code: "por"
         Text: "Est?reo"
       - Descriptor 3: Component (0x50, 80), 7 bytes
-        Content/type: 0x05B2 (H.264/AVC)
+        Content/type: 0xF5B2 (H.264/AVC)
         Component tag: 0x00 (0)
         Language: por
         Description: " "
@@ -199,7 +199,7 @@
         Language code: "por"
         Text: "Est?reo"
       - Descriptor 3: Component (0x50, 80), 7 bytes
-        Content/type: 0x05B2 (H.264/AVC)
+        Content/type: 0xF5B2 (H.264/AVC)
         Component tag: 0x00 (0)
         Language: por
         Description: " "


### PR DESCRIPTION
Display the actual value of stream_content_ext read in from the bitstream but provide a warning it is not 0xF according to NOTE 1 of Table 26 in ETSI EN 300 468. Also warn if the XML document does not contain 0xF.
Previously, this nibble was printed as "0", which masked any bitstream problem and did not accurately align with EN 300 468. The receiving device should always ignore this value (hence the n/a in Table 26 for stream_content values of 1..8)