### PR TITLE
Fix typo in HDR Vivid video desciptor output

### DIFF
--- a/reference/test-115/test-115.tstabdump.txt
+++ b/reference/test-115/test-115.tstabdump.txt
@@ -62,7 +62,7 @@
     Format identifier: 0x63757676 ("cuvv")
   - Descriptor 15: HDR Vivid Video (0xF3, 243), 10 bytes
     CUVV Tag: cuvv (0x63757676), provider code: 0x0004, provider oriented code: 4.0 (0x0008)
-    Verson Map:   1   3
+    Version Map:   1   3
   - Descriptor 16: Private Data Specifier (0x5F, 95), 4 bytes
     Specifier: 0x414F4D53 (AOM)
   - Descriptor 17: AV1 Video (0x80, 128), 4 bytes

--- a/reference/test-115/test-115.tstables.txt
+++ b/reference/test-115/test-115.tstables.txt
@@ -63,7 +63,7 @@
       Format identifier: 0x63757676 ("cuvv")
     - Descriptor 15: HDR Vivid Video (0xF3, 243), 10 bytes
       CUVV Tag: cuvv (0x63757676), provider code: 0x0004, provider oriented code: 4.0 (0x0008)
-      Verson Map:   1   3
+      Version Map:   1   3
     - Descriptor 16: Private Data Specifier (0x5F, 95), 4 bytes
       Specifier: 0x414F4D53 (AOM)
     - Descriptor 17: AV1 Video (0x80, 128), 4 bytes


### PR DESCRIPTION
Just fix a spelling mistake
